### PR TITLE
Fix role tag alignment in workspace members list

### DIFF
--- a/frontend/components/WorkspaceSettings.vue
+++ b/frontend/components/WorkspaceSettings.vue
@@ -57,7 +57,7 @@
             </div>
           </div>
 
-          <div class="flex items-center gap-2">
+          <div class="grid grid-cols-[auto_1rem] items-center gap-2">
             <!-- Role badge / dropdown -->
             <div v-if="isOwner && member.userId !== authStore.user?.id" class="relative">
               <select
@@ -84,6 +84,7 @@
             >
               &times;
             </button>
+            <span v-else class="w-4" aria-hidden="true"></span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Prevent role badge shifting in the workspace members list by ensuring the right-side action area uses a fixed layout so the role tag stays aligned across rows.

### Description
- Replace the right-side `flex` container with a fixed two-column CSS grid and add a hidden spacer when the remove button is not shown in `frontend/components/WorkspaceSettings.vue` so role labels and controls keep consistent alignment.

#### Current Behavior 
<img width="294" height="368" alt="Screenshot 2026-02-19 at 2 32 06 PM" src="https://github.com/user-attachments/assets/73549d6a-2e04-4be9-958e-5c931becc038" />


### Testing
- Ran `npx vue-tsc --noEmit` which completed successfully.
- Ran `npm run dev` which failed in this environment due to `foreman` not being available.
- Started the dev server with `npx vite --host 0.0.0.0 --port 4173` but an automated Playwright navigation to the dev URL returned `ERR_EMPTY_RESPONSE`, so a screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69978f93822083269b27114de25a8bba)