### PR TITLE
fix: Optimize follow-up queries, auto-resolve resources, and fix PI tool usage

### DIFF
--- a/agent_service/agent/integrations/mcp/client_manager.py
+++ b/agent_service/agent/integrations/mcp/client_manager.py
@@ -83,7 +83,7 @@ class MCPClientManager:
                     name=name,
                     transport="stdio",
                     command="npx",
-                    args=["-y", "@sentry/mcp-server", "--organization-slug", sentry_org],
+                    args=["-y", "@sentry/mcp-server@latest"],
                     env={"SENTRY_ACCESS_TOKEN": sentry_token},
                 ))
 
@@ -200,7 +200,10 @@ class MCPClientManager:
         return [
             t["tool"]
             for t in self._tools.values()
-            if t["server"] in integrations
+            if any(
+                t["server"] == name or t["server"].startswith(f"{name}-")
+                for name in integrations
+            )
         ]
 
     async def call_tool(self, tool_name: str, args: dict[str, Any]) -> Any:

--- a/agent_service/agent/investigation_context.py
+++ b/agent_service/agent/investigation_context.py
@@ -236,6 +236,7 @@ class InvestigationContext:
         self.investigation_plan: InvestigationPlan | None = None
         self.critical_signals: list[dict[str, Any]] = []
         self.correlation_summary: str | None = None
+        self.pi_findings: list[dict[str, Any]] = []
 
     # ── Parse user message ──────────────────────────────────────
 
@@ -295,6 +296,10 @@ class InvestigationContext:
         result_str = result if isinstance(result, str) else __import__("json").dumps(result)
 
         self._extract_resources(tool_name, integration, result_str)
+
+        # Extract Performance Insights findings
+        if integration == "aws":
+            self._extract_pi_findings(tool_name, args, result_str)
 
         # AWS regions
         if integration == "aws":
@@ -511,6 +516,84 @@ class InvestigationContext:
             for m in re.findall(r'"(?:slug|project_slug)"\s*:\s*"([^"]+)"', result_str):
                 self._add_resource(ResourceEntry(name=m, type="sentry_project"))
 
+    def _extract_pi_findings(self, tool_name: str, args: dict[str, Any], result_str: str) -> None:
+        """Extract Performance Insights findings (top SQL, load metrics) from PI tool results."""
+        import json
+
+        tool_lower = tool_name.lower()
+        is_dimension_keys = "describe_dimension_keys" in tool_lower or "describe-dimension-keys" in tool_lower
+        is_resource_metrics = "get_resource_metrics" in tool_lower or "get-resource-metrics" in tool_lower
+
+        if not is_dimension_keys and not is_resource_metrics:
+            return
+
+        try:
+            data = json.loads(result_str)
+        except (json.JSONDecodeError, TypeError):
+            return
+
+        if not isinstance(data, dict):
+            return
+
+        if is_dimension_keys:
+            # Extract top SQL queries with their load values from Keys[]
+            keys = data.get("Keys", [])
+            if not keys:
+                return
+            finding: dict[str, Any] = {
+                "type": "top_sql_queries",
+                "source_tool": tool_name,
+                "metric": args.get("Metric", "db.load"),
+                "queries": [],
+            }
+            for key in keys[:10]:  # Top 10 queries
+                dimensions = key.get("Dimensions", {})
+                total = key.get("Total")
+                sql = (
+                    dimensions.get("db.sql_tokenized.statement")
+                    or dimensions.get("db.sql.statement")
+                    or dimensions.get("db.sql_tokenized.id")
+                    or str(dimensions)
+                )
+                entry = {"sql": sql, "load": total}
+                if dimensions.get("db.sql_tokenized.id"):
+                    entry["sql_id"] = dimensions["db.sql_tokenized.id"]
+                finding["queries"].append(entry)
+            if finding["queries"]:
+                self.pi_findings.append(finding)
+                logger.info(
+                    "Extracted %d PI top SQL queries (highest load: %.2f)",
+                    len(finding["queries"]),
+                    finding["queries"][0].get("load", 0) or 0,
+                )
+
+        elif is_resource_metrics:
+            # Extract peak/avg load from MetricList[].DataPoints[]
+            metric_list = data.get("MetricList", [])
+            if not metric_list:
+                return
+            finding = {
+                "type": "resource_metrics",
+                "source_tool": tool_name,
+                "metrics": [],
+            }
+            for metric_entry in metric_list:
+                metric_key = metric_entry.get("Key", {})
+                data_points = metric_entry.get("DataPoints", [])
+                if not data_points:
+                    continue
+                values = [dp.get("Value", 0) for dp in data_points if dp.get("Value") is not None]
+                if values:
+                    finding["metrics"].append({
+                        "metric": metric_key.get("Metric", ""),
+                        "group_by": metric_key.get("Dimensions", {}),
+                        "peak": max(values),
+                        "avg": sum(values) / len(values),
+                        "data_points": len(values),
+                    })
+            if finding["metrics"]:
+                self.pi_findings.append(finding)
+
     def _add_resource(self, entry: ResourceEntry) -> None:
         if not entry.name:
             return
@@ -647,6 +730,21 @@ class InvestigationContext:
                     attr_parts = ", ".join(f"{k}={v}" for k, v in r.attrs.items() if v)
                     parts.append(f"- {r.name}{id_part}{f' [{attr_parts}]' if attr_parts else ''}")
 
+        if self.pi_findings:
+            parts.append("\n**Performance Insights Data (REAL — cite these exactly, do NOT fabricate SQL):**")
+            for finding in self.pi_findings:
+                if finding["type"] == "top_sql_queries":
+                    parts.append(f"  _Top SQL by {finding.get('metric', 'db.load')} (from {finding['source_tool']}):_")
+                    for i, q in enumerate(finding.get("queries", []), 1):
+                        load_str = f" (load: {q['load']:.2f})" if q.get("load") is not None else ""
+                        parts.append(f"  {i}. `{q['sql']}`{load_str}")
+                elif finding["type"] == "resource_metrics":
+                    for m in finding.get("metrics", []):
+                        parts.append(
+                            f"  - {m['metric']}: peak={m['peak']:.2f}, avg={m['avg']:.2f} "
+                            f"({m['data_points']} data points)"
+                        )
+
         if self.investigation_plan:
             parts.append(f"\n{self.investigation_plan.build_status_summary()}")
 
@@ -687,6 +785,8 @@ class InvestigationContext:
             d["criticalSignals"] = self.critical_signals
         if self.correlation_summary:
             d["correlationSummary"] = self.correlation_summary
+        if self.pi_findings:
+            d["piFindings"] = self.pi_findings
         return d
 
     @classmethod
@@ -723,6 +823,7 @@ class InvestigationContext:
             ctx.investigation_plan = InvestigationPlan.from_dict(snapshot["investigationPlan"])
         ctx.critical_signals = snapshot.get("criticalSignals", [])
         ctx.correlation_summary = snapshot.get("correlationSummary")
+        ctx.pi_findings = snapshot.get("piFindings", [])
         return ctx
 
     def parse_all_user_messages(self, messages: list[dict[str, str]]) -> None:

--- a/agent_service/agent/investigation_context.py
+++ b/agent_service/agent/investigation_context.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class ResourceEntry:
@@ -40,6 +43,172 @@ class ResourceEntry:
         )
 
 
+# ── Investigation Plan ─────────────────────────────────────────
+
+# Mapping from incident keywords to required checks
+INCIDENT_TYPE_CHECKS: dict[str, list[dict[str, Any]]] = {
+    "rds": [
+        {"check_id": "cw_rds_cpu", "agent_id": "infrastructure", "description": "CloudWatch RDS CPUUtilization, DatabaseConnections, FreeableMemory", "tool_patterns": ["cloudwatch", "get-metric"]},
+        {"check_id": "cw_rds_io", "agent_id": "infrastructure", "description": "CloudWatch RDS ReadLatency, WriteLatency, ReadIOPS, WriteIOPS, DiskQueueDepth", "tool_patterns": ["cloudwatch", "get-metric"]},
+        {"check_id": "pi_rds", "agent_id": "infrastructure", "description": "Performance Insights top SQL queries and wait events", "tool_patterns": ["pi", "performance-insights"]},
+        {"check_id": "rds_events", "agent_id": "infrastructure", "description": "RDS event log for recent events", "tool_patterns": ["rds", "describe-events"]},
+        {"check_id": "sentry_errors", "agent_id": "error_monitoring", "description": "Sentry errors in incident time window", "tool_patterns": ["sentry"]},
+        {"check_id": "apm_golden", "agent_id": "apm", "description": "APM golden metrics (throughput, error rate, response time)", "tool_patterns": ["newrelic", "nrql"]},
+        {"check_id": "apm_db", "agent_id": "apm", "description": "APM database/datastore operation latency", "tool_patterns": ["newrelic", "nrql", "datastore"]},
+        {"check_id": "apm_logs", "agent_id": "apm", "description": "APM log analysis for error patterns", "tool_patterns": ["newrelic", "nrql", "log"]},
+    ],
+    "ecs": [
+        {"check_id": "cw_ecs", "agent_id": "infrastructure", "description": "CloudWatch ECS CPUUtilization, MemoryUtilization, task counts", "tool_patterns": ["cloudwatch", "get-metric"]},
+        {"check_id": "ecs_events", "agent_id": "infrastructure", "description": "ECS service events and task failures", "tool_patterns": ["ecs", "describe"]},
+        {"check_id": "cw_logs", "agent_id": "infrastructure", "description": "CloudWatch Logs error patterns", "tool_patterns": ["logs", "filter-log-events"]},
+        {"check_id": "sentry_errors", "agent_id": "error_monitoring", "description": "Sentry errors in incident time window", "tool_patterns": ["sentry"]},
+        {"check_id": "apm_golden", "agent_id": "apm", "description": "APM golden metrics", "tool_patterns": ["newrelic", "nrql"]},
+        {"check_id": "apm_logs", "agent_id": "apm", "description": "APM log analysis for error patterns", "tool_patterns": ["newrelic", "nrql", "log"]},
+    ],
+    "lambda": [
+        {"check_id": "cw_lambda", "agent_id": "infrastructure", "description": "CloudWatch Lambda Duration, Errors, Throttles, ConcurrentExecutions", "tool_patterns": ["cloudwatch", "get-metric"]},
+        {"check_id": "cw_logs", "agent_id": "infrastructure", "description": "CloudWatch Logs for Lambda error patterns", "tool_patterns": ["logs", "filter-log-events"]},
+        {"check_id": "sentry_errors", "agent_id": "error_monitoring", "description": "Sentry errors in incident time window", "tool_patterns": ["sentry"]},
+        {"check_id": "apm_golden", "agent_id": "apm", "description": "APM golden metrics", "tool_patterns": ["newrelic", "nrql"]},
+    ],
+    "ec2": [
+        {"check_id": "cw_ec2", "agent_id": "infrastructure", "description": "CloudWatch EC2 CPUUtilization, StatusCheckFailed, NetworkIn/Out", "tool_patterns": ["cloudwatch", "get-metric"]},
+        {"check_id": "ec2_status", "agent_id": "infrastructure", "description": "EC2 instance status checks", "tool_patterns": ["ec2", "describe"]},
+        {"check_id": "cw_logs", "agent_id": "infrastructure", "description": "CloudWatch Logs for error patterns", "tool_patterns": ["logs", "filter-log-events"]},
+        {"check_id": "sentry_errors", "agent_id": "error_monitoring", "description": "Sentry errors in incident time window", "tool_patterns": ["sentry"]},
+        {"check_id": "apm_golden", "agent_id": "apm", "description": "APM golden metrics", "tool_patterns": ["newrelic", "nrql"]},
+    ],
+    "generic": [
+        {"check_id": "sentry_errors", "agent_id": "error_monitoring", "description": "Sentry errors in incident time window", "tool_patterns": ["sentry"]},
+        {"check_id": "apm_golden", "agent_id": "apm", "description": "APM golden metrics", "tool_patterns": ["newrelic", "nrql"]},
+        {"check_id": "apm_logs", "agent_id": "apm", "description": "APM log analysis", "tool_patterns": ["newrelic", "nrql", "log"]},
+        {"check_id": "cw_alarms", "agent_id": "infrastructure", "description": "CloudWatch alarm states", "tool_patterns": ["cloudwatch", "describe-alarms"]},
+    ],
+}
+
+# Keywords that map incident descriptions to types
+INCIDENT_TYPE_KEYWORDS: dict[str, list[str]] = {
+    "rds": ["rds", "database", "db", "aurora", "postgres", "mysql", "mariadb", "sql"],
+    "ecs": ["ecs", "fargate", "container", "task"],
+    "lambda": ["lambda", "serverless", "function"],
+    "ec2": ["ec2", "instance", "server", "compute"],
+}
+
+
+class InvestigationPlan:
+    """Tracks what checks are required and what's been done."""
+
+    def __init__(self) -> None:
+        self.required_checks: list[dict[str, Any]] = []
+        self.findings: list[dict[str, Any]] = []
+        self.missing_data: list[str] = []
+
+    @classmethod
+    def generate_plan(cls, incident_description: str) -> InvestigationPlan:
+        """Generate a pre-populated plan based on the incident type."""
+        plan = cls()
+        lower = incident_description.lower()
+
+        matched_type = "generic"
+        for incident_type, keywords in INCIDENT_TYPE_KEYWORDS.items():
+            if any(kw in lower for kw in keywords):
+                matched_type = incident_type
+                break
+
+        template_checks = INCIDENT_TYPE_CHECKS.get(matched_type, INCIDENT_TYPE_CHECKS["generic"])
+        for check_template in template_checks:
+            plan.required_checks.append({
+                **check_template,
+                "status": "pending",
+            })
+
+        logger.info("Generated investigation plan: type=%s, checks=%d", matched_type, len(plan.required_checks))
+        return plan
+
+    def mark_check_complete(self, check_id: str, findings_summary: str) -> None:
+        for check in self.required_checks:
+            if check["check_id"] == check_id:
+                check["status"] = "complete"
+                break
+        self.findings.append({"check_id": check_id, "summary": findings_summary})
+
+    def mark_check_by_tool(self, tool_name: str, agent_id: str) -> None:
+        """Mark checks as complete based on a tool that was called."""
+        tool_lower = tool_name.lower()
+        for check in self.required_checks:
+            if check["status"] != "pending" or check["agent_id"] != agent_id:
+                continue
+            if any(pat in tool_lower for pat in check["tool_patterns"]):
+                check["status"] = "complete"
+
+    def get_incomplete_checks(self) -> list[dict[str, Any]]:
+        return [c for c in self.required_checks if c["status"] == "pending"]
+
+    def get_checks_for_agent(self, agent_id: str) -> list[dict[str, Any]]:
+        return [c for c in self.required_checks if c["agent_id"] == agent_id and c["status"] == "pending"]
+
+    def add_finding(self, agent_id: str, iteration: int, summary: str, severity: str = "info", evidence: str = "") -> None:
+        self.findings.append({
+            "agent_id": agent_id,
+            "iteration": iteration,
+            "summary": summary,
+            "severity": severity,
+            "evidence": evidence,
+        })
+
+    def build_status_summary(self) -> str:
+        completed = [c for c in self.required_checks if c["status"] == "complete"]
+        pending = self.get_incomplete_checks()
+
+        lines = [f"**Investigation Plan:** {len(completed)}/{len(self.required_checks)} checks complete"]
+
+        if completed:
+            lines.append("\nCompleted:")
+            for c in completed:
+                lines.append(f"  - [done] {c['description']}")
+
+        if pending:
+            lines.append("\nPending:")
+            for c in pending:
+                lines.append(f"  - [TODO] {c['description']} (→ {c['agent_id']})")
+
+        if self.missing_data:
+            lines.append("\nMissing data:")
+            for gap in self.missing_data:
+                lines.append(f"  - {gap}")
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "requiredChecks": self.required_checks,
+            "findings": self.findings,
+            "missingData": self.missing_data,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InvestigationPlan:
+        plan = cls()
+        plan.required_checks = data.get("requiredChecks", [])
+        plan.findings = data.get("findings", [])
+        plan.missing_data = data.get("missingData", [])
+        return plan
+
+
+# ── Critical Signal Detection ─────────────────────────────────
+
+CRITICAL_PATTERNS: dict[str, str] = {
+    r"PG::QueryCanceled": "database_timeout",
+    r"OOM|Out of memory|OutOfMemoryError": "memory_exhaustion",
+    r"connection refused|connection timeout|ECONNREFUSED": "connectivity_failure",
+    r"CPU.*9[0-9]%|CPU.*100%|CPUUtilization.*9[0-9]|CPUUtilization.*100": "cpu_saturation",
+    r"deadlock|Deadlock": "deadlock",
+    r"disk full|no space left|ENOSPC": "disk_exhaustion",
+    r"throttl|rate.?limit|429": "throttling",
+    r"max_connections|too many connections|connection pool exhausted": "connection_exhaustion",
+}
+
+
 class InvestigationContext:
     """Tracks investigation state across the agent loop.
 
@@ -64,6 +233,9 @@ class InvestigationContext:
         }
         self.resources: list[ResourceEntry] = []
         self.scoped_group_name: str | None = None
+        self.investigation_plan: InvestigationPlan | None = None
+        self.critical_signals: list[dict[str, Any]] = []
+        self.correlation_summary: str | None = None
 
     # ── Parse user message ──────────────────────────────────────
 
@@ -147,10 +319,12 @@ class InvestigationContext:
             if m:
                 try:
                     incident_time = datetime.fromisoformat(m.group(1).replace("Z", "+00:00"))
+                    # Normalize to UTC
+                    incident_time = incident_time.astimezone(timezone.utc)
                     start = incident_time - timedelta(hours=1)
                     end = incident_time + timedelta(hours=1)
                     self.time_window = {
-                        "description": f"around incident time {incident_time.isoformat()}",
+                        "description": f"around incident time {incident_time.strftime('%Y-%m-%d %H:%M:%S')} UTC",
                         "start": start,
                         "end": end,
                         "extracted": True,
@@ -351,6 +525,42 @@ class InvestigationContext:
                 return
         self.resources.append(entry)
 
+    # ── Investigation plan ────────────────────────────────────────
+
+    def generate_investigation_plan(self, incident_description: str) -> None:
+        """Generate and attach an investigation plan based on the incident description."""
+        self.investigation_plan = InvestigationPlan.generate_plan(incident_description)
+
+    # ── Critical signals ───────────────────────────────────────
+
+    def add_critical_signal(self, signal: dict[str, Any]) -> None:
+        """Add a critical signal detected from tool output."""
+        # Deduplicate by pattern + category
+        for existing in self.critical_signals:
+            if existing["category"] == signal["category"] and existing.get("match") == signal.get("match"):
+                return
+        self.critical_signals.append(signal)
+
+    def build_evidence_brief(self) -> str | None:
+        """Summarize all critical signals grouped by category."""
+        if not self.critical_signals:
+            return None
+
+        by_category: dict[str, list[dict[str, Any]]] = {}
+        for sig in self.critical_signals:
+            by_category.setdefault(sig["category"], []).append(sig)
+
+        lines = ["**Critical Signals Detected:**"]
+        for category, signals in by_category.items():
+            lines.append(f"\n_{category}_:")
+            for sig in signals:
+                source = sig.get("source_tool", "unknown")
+                agent = sig.get("agent_id", "unknown")
+                match_text = sig.get("match", "")
+                lines.append(f"  - [{agent}/{source}] {match_text}")
+
+        return "\n".join(lines)
+
     # ── Context message for model ───────────────────────────────
 
     def build_context_message(self) -> str | None:
@@ -360,15 +570,40 @@ class InvestigationContext:
         end = self.time_window.get("end")
 
         if start and end:
-            padded_start = start - timedelta(minutes=30)
-            window_ms = (end - start).total_seconds() * 1000
+            # Normalize to UTC for consistency
+            utc_start = start.astimezone(timezone.utc) if start.tzinfo else start.replace(tzinfo=timezone.utc)
+            utc_end = end.astimezone(timezone.utc) if end.tzinfo else end.replace(tzinfo=timezone.utc)
+            padded_start = utc_start - timedelta(minutes=30)
+            window_ms = (utc_end - utc_start).total_seconds() * 1000
             is_broad = window_ms > 3 * 24 * 60 * 60 * 1000
+
+            # Format as UTC strings (no timezone offset — safe for all query languages)
+            start_utc_str = utc_start.strftime("%Y-%m-%d %H:%M:%S")
+            end_utc_str = utc_end.strftime("%Y-%m-%d %H:%M:%S")
+            padded_start_utc_str = padded_start.strftime("%Y-%m-%d %H:%M:%S")
+
+            # Calculate NRQL-safe relative time (hours ago from now)
+            now = datetime.now(timezone.utc)
+            hours_since_start = (now - utc_start).total_seconds() / 3600
+            hours_since_end = (now - utc_end).total_seconds() / 3600
+
+            # Epoch milliseconds for AWS CloudWatch
+            start_epoch_ms = int(utc_start.timestamp() * 1000)
+            end_epoch_ms = int(utc_end.timestamp() * 1000)
 
             parts.append(
                 f"**Investigation time window:** {self.time_window['description']}\n"
-                f"  start: {start.isoformat()}\n"
-                f"  end:   {end.isoformat()}\n"
-                f"  query_start (padded -30min): {padded_start.isoformat()}"
+                f"  start (UTC): {start_utc_str}\n"
+                f"  end (UTC):   {end_utc_str}\n"
+                f"  padded_start (UTC, -30min): {padded_start_utc_str}\n"
+                f"\n"
+                f"  **NRQL time (use these EXACTLY):**\n"
+                f"    Absolute: SINCE '{padded_start_utc_str}' UNTIL '{end_utc_str}'\n"
+                f"    Relative: SINCE {int(hours_since_start) + 1} hours ago UNTIL {max(0, int(hours_since_end))} hours ago\n"
+                f"\n"
+                f"  **AWS CloudWatch epoch ms:**\n"
+                f"    startTime: {start_epoch_ms}\n"
+                f"    endTime: {end_epoch_ms}"
             )
             if is_broad:
                 parts.append(
@@ -412,6 +647,16 @@ class InvestigationContext:
                     attr_parts = ", ".join(f"{k}={v}" for k, v in r.attrs.items() if v)
                     parts.append(f"- {r.name}{id_part}{f' [{attr_parts}]' if attr_parts else ''}")
 
+        if self.investigation_plan:
+            parts.append(f"\n{self.investigation_plan.build_status_summary()}")
+
+        evidence = self.build_evidence_brief()
+        if evidence:
+            parts.append(f"\n{evidence}")
+
+        if self.correlation_summary:
+            parts.append(f"\n**Cross-Agent Correlation:**\n{self.correlation_summary}")
+
         return "\n".join(parts)
 
     # ── Serialization ───────────────────────────────────────────
@@ -436,16 +681,31 @@ class InvestigationContext:
         }
         if self.scoped_group_name:
             d["scopedGroupName"] = self.scoped_group_name
+        if self.investigation_plan:
+            d["investigationPlan"] = self.investigation_plan.to_dict()
+        if self.critical_signals:
+            d["criticalSignals"] = self.critical_signals
+        if self.correlation_summary:
+            d["correlationSummary"] = self.correlation_summary
         return d
 
     @classmethod
     def from_dict(cls, snapshot: dict[str, Any]) -> InvestigationContext:
         ctx = cls()
         tw = snapshot.get("timeWindow", {})
+
+        def _parse_utc(val: str | None) -> datetime | None:
+            if not val:
+                return None
+            dt = datetime.fromisoformat(val)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+
         ctx.time_window = {
             "description": tw.get("description", "last 24 hours"),
-            "start": datetime.fromisoformat(tw["start"]) if tw.get("start") else None,
-            "end": datetime.fromisoformat(tw["end"]) if tw.get("end") else None,
+            "start": _parse_utc(tw.get("start")),
+            "end": _parse_utc(tw.get("end")),
             "extracted": tw.get("extracted", False),
         }
         ctx.entities = snapshot.get("entities", {})
@@ -459,6 +719,10 @@ class InvestigationContext:
         }
         ctx.resources = [ResourceEntry.from_dict(r) for r in snapshot.get("resources", [])]
         ctx.scoped_group_name = snapshot.get("scopedGroupName")
+        if snapshot.get("investigationPlan"):
+            ctx.investigation_plan = InvestigationPlan.from_dict(snapshot["investigationPlan"])
+        ctx.critical_signals = snapshot.get("criticalSignals", [])
+        ctx.correlation_summary = snapshot.get("correlationSummary")
         return ctx
 
     def parse_all_user_messages(self, messages: list[dict[str, str]]) -> None:

--- a/agent_service/agent/orchestrator.py
+++ b/agent_service/agent/orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import uuid
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator
 
@@ -18,7 +19,7 @@ from .integrations.aws import register_aws_tools
 from .integrations.newrelic import register_newrelic_tools
 from .integrations.pagerduty import register_pagerduty_tools
 from .name_matcher import normalize_name
-from .prompts import SYSTEM, EVALUATION_SYSTEM
+from .prompts import SYSTEM, EVALUATION_SYSTEM, CORRELATION_ANALYSIS
 from .sub_agents import (
     BaseSubAgent,
     SubAgentConfig,
@@ -33,7 +34,10 @@ from .models import AgentRunRequest, ResourceMap, ResourceNode
 logger = logging.getLogger(__name__)
 
 MAX_ORCHESTRATOR_ITERATIONS = 4
+MAX_EXTENDED_ITERATIONS = 8
 CONFIDENCE_THRESHOLD = 60
+MAX_SUBAGENT_FINDINGS_CHARS = 8_000
+MAX_TOTAL_CONTEXT_CHARS = 80_000
 
 INTEGRATION_TO_AGENT: dict[str, SubAgentType] = {
     "newrelic": "apm",
@@ -109,6 +113,12 @@ async def orchestrate(request: AgentRunRequest) -> AsyncGenerator[str, None]:
     else:
         ctx = InvestigationContext()
         ctx.parse_all_user_messages([{"role": m.role, "content": m.content} for m in request.messages])
+
+    # Generate investigation plan from user message
+    if not ctx.investigation_plan and user_messages:
+        incident_desc = user_messages[-1].content if user_messages else ""
+        if incident_desc:
+            ctx.generate_investigation_plan(incident_desc)
 
     # Create sub-agents
     domain_integrations = [i for i in enabled_integrations if i != "github"]
@@ -248,32 +258,49 @@ async def _run_orchestrator(
     # ── ORCHESTRATOR LOOP ─────────────────────────────────────
     all_text_chunks: list[str] = []
     all_text_chunks.extend(triage_result.get("chunks", []))
+    next_forced_dispatch: dict[str, Any] | None = None
+    evaluation: dict[str, Any] | None = None
 
     for iteration in range(MAX_ORCHESTRATOR_ITERATIONS):
         yield _sse_event({"type": "iteration_start", "iteration": iteration})
 
         if iteration > 0:
-            # Get new dispatch
-            dispatch_call = await _dispatch(
-                client, model, input_items, orchestrator_prompt, internal_tools,
-                total_tokens, ctx, resource_maps, sub_agents,
-            )
-            if not dispatch_call:
-                break
+            # Context budget check — summarize older findings if approaching limit
+            context_size = _estimate_context_chars(input_items)
+            if context_size > MAX_TOTAL_CONTEXT_CHARS * 0.8:
+                logger.info("Context size %d chars approaching limit, summarizing older findings", context_size)
+                await _summarize_older_findings(client, input_items, app_config.openai_summary_model)
 
-            input_items.append(dispatch_call)
+            # Check if we have a forced dispatch from next_steps enforcement
+            if next_forced_dispatch:
+                active_call_id = next_forced_dispatch["call_id"]
+                assignments = next_forced_dispatch["assignments"]
+                next_forced_dispatch = None
+            else:
+                # Get new dispatch from the model
+                dispatch_call = await _dispatch(
+                    client, model, input_items, orchestrator_prompt, internal_tools,
+                    total_tokens, ctx, resource_maps, sub_agents,
+                )
+                if not dispatch_call:
+                    break
 
-            try:
-                parsed = json.loads(dispatch_call["arguments"])
-                assignments = [a for a in parsed.get("agents", []) if a["agentId"] in sub_agents]
-            except (json.JSONDecodeError, KeyError):
-                break
+                input_items.append(dispatch_call)
 
-            if not assignments:
-                break
+                try:
+                    parsed = json.loads(dispatch_call["arguments"])
+                    assignments = [a for a in parsed.get("agents", []) if a["agentId"] in sub_agents]
+                except (json.JSONDecodeError, KeyError):
+                    break
+
+                if not assignments:
+                    break
+
+                active_call_id = dispatch_call["call_id"]
 
         # ── Run sub-agents ────────────────────────────────────
-        active_call_id = first_dispatch_call["call_id"] if iteration == 0 else dispatch_call["call_id"]  # noqa: F821
+        if iteration == 0:
+            active_call_id = first_dispatch_call["call_id"]
         results = []
 
         for assignment in assignments:
@@ -328,7 +355,14 @@ async def _run_orchestrator(
                     token_usage={"input": 0, "output": 0},
                 ))
 
-        # Add findings
+        # Add findings (truncate each sub-agent's findings to budget)
+        for r in results:
+            if len(r.findings) > MAX_SUBAGENT_FINDINGS_CHARS:
+                r.findings = (
+                    r.findings[:MAX_SUBAGENT_FINDINGS_CHARS]
+                    + f"\n\n[... truncated {len(r.findings) - MAX_SUBAGENT_FINDINGS_CHARS} chars]"
+                )
+
         findings_summary = "\n\n---\n\n".join(
             f"## {r.agent_id} Agent Findings ({len(r.tools_used)} tools, {r.iterations} iterations)\n{r.findings}"
             for r in results
@@ -339,6 +373,15 @@ async def _run_orchestrator(
             "output": findings_summary,
         })
 
+        # ── Cross-agent correlation ──────────────────────────
+        correlation = await _correlate_findings(client, results, ctx, total_tokens)
+        if correlation:
+            yield _sse_event({"type": "correlation", "summary": correlation})
+            input_items.append({
+                "role": "developer",
+                "content": f"[Cross-Agent Correlation]\n{correlation}",
+            })
+
         # ── Evaluate ──────────────────────────────────────────
         is_last = iteration >= MAX_ORCHESTRATOR_ITERATIONS - 1
 
@@ -348,7 +391,7 @@ async def _run_orchestrator(
                 "content": 'This is the last orchestrator iteration. Strongly consider marking as "complete" unless critical data is clearly missing.',
             })
 
-        evaluation = await _evaluate(client, model, input_items, orchestrator_prompt, internal_tools, total_tokens)
+        evaluation = await _evaluate(client, model, input_items, orchestrator_prompt, internal_tools, total_tokens, results)
 
         yield _sse_event({
             "type": "reasoning",
@@ -373,7 +416,7 @@ async def _run_orchestrator(
             yield _sse_event({"type": "token_usage", **total_tokens})
 
             async for chunk in _stream_final_answer(
-                client, model, input_items, orchestrator_prompt, is_last and not should_complete,
+                client, model, input_items, orchestrator_prompt, is_last and not should_complete, ctx,
             ):
                 all_text_chunks.append(chunk)
                 yield _sse_event({"type": "text_delta", "text": chunk})
@@ -392,20 +435,175 @@ async def _run_orchestrator(
 
             # Generate title if needed
             if not has_title:
-                async for evt in _generate_title(client, request):
+                async for evt in _generate_title(client, request, "".join(all_text_chunks)):
                     yield evt
 
             return
 
+        # Resolve next_steps into concrete dispatches for the next iteration
+        next_steps = evaluation["result"].get("next_steps", [])
+        if next_steps:
+            forced_assignments = _resolve_next_steps_to_dispatch(next_steps, sub_agents, ctx)
+            if forced_assignments:
+                logger.info(
+                    "Enforcing next_steps as dispatches: %s",
+                    [(a["agentId"], a["task"][:80]) for a in forced_assignments],
+                )
+                # Inject as a forced dispatch for the next iteration
+                forced_dispatch = json.dumps({"agents": forced_assignments})
+                forced_call_id = f"forced-{uuid.uuid4()}"
+                input_items.append({
+                    "type": "function_call",
+                    "call_id": forced_call_id,
+                    "name": "_dispatch",
+                    "arguments": forced_dispatch,
+                })
+                # We'll handle execution in the next iteration by setting assignments directly
+                # Store for the next iteration to pick up
+                next_forced_dispatch = {
+                    "call_id": forced_call_id,
+                    "assignments": forced_assignments,
+                }
+            else:
+                next_forced_dispatch = None
+        else:
+            next_forced_dispatch = None
+
         if evaluation["result"]["status"] == "complete" and evaluation["result"]["confidence"] < CONFIDENCE_THRESHOLD:
             input_items.append({
                 "role": "developer",
-                "content": f"[Evaluation Override] Confidence {evaluation['result']['confidence']}% is below threshold. Continue investigating. Focus on: {', '.join(evaluation['result'].get('next_steps', [])) or 'filling gaps'}",
+                "content": f"[Evaluation Override] Confidence {evaluation['result']['confidence']}% is below threshold. Continue investigating. Focus on: {', '.join(next_steps) or 'filling gaps'}",
             })
 
-    # Exhausted iterations
+    # Check if we should extend the investigation
+    last_confidence = evaluation["result"]["confidence"] if evaluation else 0  # type: ignore[possibly-undefined]
+    incomplete_checks = ctx.investigation_plan.get_incomplete_checks() if ctx.investigation_plan else []
+
+    if last_confidence < 40 and incomplete_checks:
+        logger.warning(
+            "Extending investigation: confidence=%d%%, incomplete_checks=%d",
+            last_confidence, len(incomplete_checks),
+        )
+        yield _sse_event({
+            "type": "investigation_extended",
+            "reason": f"Confidence {last_confidence}% with {len(incomplete_checks)} incomplete checks",
+        })
+
+        for ext_iteration in range(MAX_ORCHESTRATOR_ITERATIONS, MAX_EXTENDED_ITERATIONS):
+            yield _sse_event({"type": "iteration_start", "iteration": ext_iteration})
+
+            # Build focused dispatch from incomplete checks only
+            incomplete = ctx.investigation_plan.get_incomplete_checks() if ctx.investigation_plan else []
+            if not incomplete:
+                break
+
+            ext_assignments: list[dict[str, str]] = []
+            dispatched: set[str] = set()
+            for check in incomplete:
+                agent_id = check["agent_id"]
+                if agent_id in sub_agents and agent_id not in dispatched:
+                    dispatched.add(agent_id)
+                    agent_checks = ctx.investigation_plan.get_checks_for_agent(agent_id) if ctx.investigation_plan else []
+                    task_desc = "Complete these required checks: " + "; ".join(c["description"] for c in agent_checks)
+                    ext_assignments.append({"agentId": agent_id, "task": task_desc})
+
+            if not ext_assignments:
+                break
+
+            # Run the focused sub-agents
+            ext_call_id = f"extended-{uuid.uuid4()}"
+            ext_results = []
+
+            for assignment in ext_assignments:
+                agent_id_str = assignment["agentId"]
+                ext_task = assignment["task"]
+                ext_agent = sub_agents[agent_id_str]
+
+                yield _sse_event({
+                    "type": "sub_agent_start",
+                    "agentId": agent_id_str,
+                    "agentType": ext_agent.agent_type,
+                    "task": ext_task,
+                })
+
+                try:
+                    tool_queue_ext: asyncio.Queue = asyncio.Queue()
+                    ext_agent_task = asyncio.create_task(
+                        ext_agent.run(ext_task, on_tool_use=lambda tu: tool_queue_ext.put_nowait(tu))
+                    )
+
+                    while not ext_agent_task.done():
+                        try:
+                            tu = await asyncio.wait_for(tool_queue_ext.get(), timeout=0.05)
+                            yield _sse_event({"type": "tool_use", "toolUse": tu})
+                        except asyncio.TimeoutError:
+                            continue
+
+                    while not tool_queue_ext.empty():
+                        yield _sse_event({"type": "tool_use", "toolUse": tool_queue_ext.get_nowait()})
+
+                    ext_result = ext_agent_task.result()
+                    ext_results.append(ext_result)
+                    total_tokens["input"] += ext_result.token_usage.get("input", 0)
+                    total_tokens["output"] += ext_result.token_usage.get("output", 0)
+
+                    yield _sse_event({
+                        "type": "sub_agent_complete",
+                        "agentId": ext_result.agent_id,
+                        "findings": ext_result.findings[:500],
+                    })
+
+                except Exception as e:
+                    logger.error("Extended sub-agent %s failed: %s", agent_id_str, e)
+                    from .sub_agents.base import SubAgentResult
+                    ext_results.append(SubAgentResult(
+                        agent_id=agent_id_str,
+                        findings=f"Investigation failed: {e}",
+                        tools_used=[],
+                        iterations=0,
+                        token_usage={"input": 0, "output": 0},
+                    ))
+
+            # Truncate and add findings
+            for r in ext_results:
+                if len(r.findings) > MAX_SUBAGENT_FINDINGS_CHARS:
+                    r.findings = r.findings[:MAX_SUBAGENT_FINDINGS_CHARS] + "\n\n[... truncated]"
+
+            ext_findings = "\n\n---\n\n".join(
+                f"## {r.agent_id} Agent Findings (extended)\n{r.findings}"
+                for r in ext_results
+            )
+            input_items.append({
+                "type": "function_call",
+                "call_id": ext_call_id,
+                "name": "_dispatch",
+                "arguments": json.dumps({"agents": ext_assignments}),
+            })
+            input_items.append({
+                "type": "function_call_output",
+                "call_id": ext_call_id,
+                "output": ext_findings,
+            })
+
+            # Correlate extended findings
+            correlation = await _correlate_findings(client, ext_results, ctx, total_tokens)
+            if correlation:
+                yield _sse_event({"type": "correlation", "summary": correlation})
+
+            # Re-evaluate
+            ext_eval = await _evaluate(client, model, input_items, orchestrator_prompt, internal_tools, total_tokens, ext_results)
+            yield _sse_event({
+                "type": "reasoning",
+                "iteration": ext_iteration,
+                "evaluation": ext_eval["result"],
+            })
+
+            if ext_eval["result"]["status"] == "complete" and ext_eval["result"]["confidence"] >= CONFIDENCE_THRESHOLD:
+                break
+
+    # Final answer
     yield _sse_event({"type": "token_usage", **total_tokens})
-    async for chunk in _stream_final_answer(client, model, input_items, orchestrator_prompt, True):
+    async for chunk in _stream_final_answer(client, model, input_items, orchestrator_prompt, True, ctx):
         all_text_chunks.append(chunk)
         yield _sse_event({"type": "text_delta", "text": chunk})
 
@@ -422,7 +620,7 @@ async def _run_orchestrator(
     })
 
     if not has_title:
-        async for evt in _generate_title(client, request):
+        async for evt in _generate_title(client, request, "".join(all_text_chunks)):
             yield evt
 
 
@@ -628,11 +826,19 @@ async def _evaluate(
     system_prompt: str,
     tools: list[Any],
     total_tokens: dict[str, int],
+    results: list[Any] | None = None,
 ) -> dict[str, Any]:
     eval_input = list(input_items)
+
+    # Build data quality summary from sub-agent results
+    quality_notes = _build_data_quality_summary(results) if results else ""
+    eval_content = EVALUATION_SYSTEM
+    if quality_notes:
+        eval_content += f"\n\n**DATA QUALITY CHECK (from sub-agent tool calls):**\n{quality_notes}\nYou MUST factor these data quality issues into your confidence score."
+
     eval_input.append({
         "role": "developer",
-        "content": EVALUATION_SYSTEM,
+        "content": eval_content,
     })
 
     response = await client.responses.create(
@@ -661,10 +867,31 @@ async def _evaluate(
 
     try:
         parsed = json.loads(eval_call.arguments)
+        confidence = min(100, max(0, parsed.get("confidence", 0)))
+
+        # Hard confidence cap: if any sub-agent had ALL tools fail/empty, cap at 50
+        if results:
+            for r in results:
+                total = len(r.tools_used)
+                if total == 0:
+                    continue
+                usable = sum(
+                    1 for tu in r.tools_used
+                    if tu.get("status") == "success" and not _is_empty_tool_output(tu.get("output", ""))
+                )
+                if usable == 0 and confidence > 50:
+                    logger.warning(
+                        "Capping confidence from %d to 50: sub-agent %s had 0/%d usable tool results",
+                        confidence, r.agent_id, total,
+                    )
+                    confidence = 50
+                    if parsed.get("status") == "complete":
+                        parsed["status"] = "continue"
+
         return {
             "result": {
                 "status": "complete" if parsed.get("status") == "complete" else "continue",
-                "confidence": min(100, max(0, parsed.get("confidence", 0))),
+                "confidence": confidence,
                 "summary": parsed.get("summary", ""),
                 "next_steps": parsed.get("next_steps", []),
             },
@@ -687,6 +914,116 @@ async def _evaluate(
         }
 
 
+# ── Next-steps enforcement ────────────────────────────────────
+
+# Keyword mapping from evaluation next_steps to agent IDs
+_NEXT_STEP_KEYWORDS: dict[str, list[str]] = {
+    "infrastructure": ["cloudwatch", "aws", "rds", "ec2", "ecs", "lambda", "metric", "alarm", "log group", "performance insights", "database metric"],
+    "apm": ["apm", "new relic", "newrelic", "nrql", "throughput", "response time", "golden metric", "transaction", "datastore"],
+    "error_monitoring": ["sentry", "error", "stack trace", "exception", "issue"],
+    "alerting": ["pagerduty", "incident", "alert", "on-call"],
+}
+
+
+def _resolve_next_steps_to_dispatch(
+    next_steps: list[str],
+    available_agents: dict[str, Any],
+    ctx: InvestigationContext,
+) -> list[dict[str, str]]:
+    """Convert evaluation next_steps into concrete sub-agent dispatch assignments."""
+    assignments: list[dict[str, str]] = []
+    dispatched_agents: set[str] = set()
+
+    for step in next_steps:
+        step_lower = step.lower()
+        matched_agent = None
+
+        for agent_id, keywords in _NEXT_STEP_KEYWORDS.items():
+            if agent_id not in available_agents:
+                continue
+            if any(kw in step_lower for kw in keywords):
+                matched_agent = agent_id
+                break
+
+        if not matched_agent:
+            continue
+
+        if matched_agent in dispatched_agents:
+            # Merge into existing assignment
+            for a in assignments:
+                if a["agentId"] == matched_agent:
+                    a["task"] += f" Additionally: {step}"
+                    break
+            continue
+
+        dispatched_agents.add(matched_agent)
+        assignments.append({"agentId": matched_agent, "task": step})
+
+    # Also check investigation plan for incomplete checks
+    if ctx.investigation_plan:
+        for check in ctx.investigation_plan.get_incomplete_checks():
+            agent_id = check["agent_id"]
+            if agent_id in available_agents and agent_id not in dispatched_agents:
+                dispatched_agents.add(agent_id)
+                assignments.append({
+                    "agentId": agent_id,
+                    "task": f"[Required check] {check['description']}",
+                })
+
+    return assignments
+
+
+# ── Cross-agent correlation ───────────────────────────────────
+
+async def _correlate_findings(
+    client: AsyncOpenAI,
+    results: list[Any],
+    ctx: InvestigationContext,
+    total_tokens: dict[str, int],
+) -> str | None:
+    """Correlate findings across sub-agents to identify causal relationships."""
+    if len(results) < 2:
+        return None
+
+    findings_text = "\n\n---\n\n".join(
+        f"## {r.agent_id} Agent Findings\n{r.findings[:4000]}"
+        for r in results
+        if r.findings
+    )
+
+    if not findings_text.strip():
+        return None
+
+    # Include critical signals if available
+    evidence = ctx.build_evidence_brief()
+    if evidence:
+        findings_text += f"\n\n---\n\n## Critical Signals\n{evidence}"
+
+    try:
+        response = await client.chat.completions.create(
+            model=app_config.openai_summary_model,
+            messages=[
+                {"role": "system", "content": CORRELATION_ANALYSIS},
+                {"role": "user", "content": findings_text},
+            ],
+            max_tokens=500,
+        )
+
+        if hasattr(response, "usage") and response.usage:
+            total_tokens["input"] += getattr(response.usage, "prompt_tokens", 0) or 0
+            total_tokens["output"] += getattr(response.usage, "completion_tokens", 0) or 0
+
+        correlation = (response.choices[0].message.content or "").strip()
+        if correlation:
+            ctx.correlation_summary = correlation
+            logger.info("Cross-agent correlation completed: %s", correlation[:200])
+            return correlation
+    except Exception as e:
+        logger.warning("Correlation analysis failed: %s", e)
+
+    return None
+
+
 # ── Final answer streaming ────────────────────────────────────
 
 async def _stream_final_answer(
@@ -695,16 +1032,25 @@ async def _stream_final_answer(
     input_items: list[Any],
     system_prompt: str,
     forced: bool,
+    ctx: InvestigationContext | None = None,
 ) -> AsyncGenerator[str, None]:
     final_input = list(input_items)
-    final_input.append({
-        "role": "developer",
-        "content": (
-            "[Phase: Final Answer] You have reached the iteration limit. Produce your final, comprehensive answer NOW using all the data gathered by sub-agents. Do not dispatch any more tasks."
-            if forced
-            else "[Phase: Final Answer] Your evaluation determined the investigation is complete. Produce your final, comprehensive diagnosis synthesizing all evidence from sub-agents."
-        ),
-    })
+
+    phase_msg = (
+        "[Phase: Final Answer] You have reached the iteration limit. Produce your final, comprehensive answer NOW using all the data gathered by sub-agents. Do not dispatch any more tasks."
+        if forced
+        else "[Phase: Final Answer] Your evaluation determined the investigation is complete. Produce your final, comprehensive diagnosis synthesizing all evidence from sub-agents."
+    )
+
+    # Include evidence brief so the synthesizer can't miss critical signals
+    if ctx:
+        evidence = ctx.build_evidence_brief()
+        if evidence:
+            phase_msg += f"\n\n{evidence}"
+        if ctx.correlation_summary:
+            phase_msg += f"\n\n**Cross-Agent Correlation:**\n{ctx.correlation_summary}"
+
+    final_input.append({"role": "developer", "content": phase_msg})
 
     stream = await client.responses.create(
         model=model,
@@ -723,16 +1069,25 @@ async def _stream_final_answer(
 async def _generate_title(
     client: AsyncOpenAI,
     request: AgentRunRequest,
+    response_text: str = "",
 ) -> AsyncGenerator[str, None]:
     summary_model = app_config.openai_summary_model
     user_msg = request.user_message
+
+    # Build title input: use user message + first part of agent response for context
+    # This helps when the user message is just a URL (agent response has the actual topic)
+    title_input = user_msg[:300]
+    if response_text:
+        # Extract the first meaningful section (usually "What Happened" or similar)
+        first_section = response_text[:400]
+        title_input = f"User asked: {title_input}\n\nAgent response summary: {first_section}"
 
     try:
         response = await client.chat.completions.create(
             model=summary_model,
             messages=[
-                {"role": "system", "content": "Generate a short, descriptive title (max 60 chars) for this conversation. Return only the title, no quotes or punctuation."},
-                {"role": "user", "content": user_msg[:500]},
+                {"role": "system", "content": "Generate a short, descriptive title (max 60 chars) for this conversation based on the topic discussed. If the user sent a URL, use the agent's response to determine the topic. Return only the title, no quotes or punctuation."},
+                {"role": "user", "content": title_input[:700]},
             ],
             max_tokens=30,
         )
@@ -981,6 +1336,141 @@ def _get_enabled_integrations(settings: dict[str, Any]) -> list[str]:
     return enabled
 
 
+def _estimate_context_chars(input_items: list[Any]) -> int:
+    """Estimate the total character count of all items in the context."""
+    total = 0
+    for item in input_items:
+        if isinstance(item, dict):
+            content = item.get("content") or item.get("output") or item.get("arguments") or ""
+            total += len(str(content))
+        else:
+            total += len(str(item))
+    return total
+
+
+async def _summarize_older_findings(
+    client: AsyncOpenAI,
+    input_items: list[Any],
+    summary_model: str,
+) -> None:
+    """Summarize older function_call_output items to reduce context size."""
+    # Find function_call_output items (sub-agent findings)
+    output_indices = [
+        i for i, item in enumerate(input_items)
+        if isinstance(item, dict) and item.get("type") == "function_call_output"
+        and len(str(item.get("output", ""))) > 2000
+    ]
+
+    if len(output_indices) < 2:
+        return  # Only summarize if we have multiple large outputs
+
+    # Summarize all but the most recent output
+    for idx in output_indices[:-1]:
+        old_output = input_items[idx].get("output", "")
+        if len(old_output) <= 2000:
+            continue
+
+        try:
+            response = await client.chat.completions.create(
+                model=summary_model,
+                messages=[
+                    {"role": "system", "content": "Summarize these investigation findings into key data points, metrics, and conclusions. Keep critical signals, error messages, and specific numbers. Be concise but don't lose important evidence."},
+                    {"role": "user", "content": old_output[:15_000]},
+                ],
+                max_tokens=500,
+            )
+            summary = (response.choices[0].message.content or "").strip()
+            if summary:
+                input_items[idx]["output"] = f"[Summarized from earlier iteration]\n{summary}"
+        except Exception as e:
+            logger.warning("Context summarization failed: %s", e)
+
+
+def _build_data_quality_summary(results: list[Any] | None) -> str:
+    """Build a data quality summary from sub-agent results to inform evaluation."""
+    if not results:
+        return ""
+
+    lines: list[str] = []
+    for r in results:
+        agent_id = r.agent_id
+        total_tools = len(r.tools_used)
+        failed_tools = sum(1 for tu in r.tools_used if tu.get("status") == "error")
+        empty_tools = sum(
+            1 for tu in r.tools_used
+            if tu.get("status") == "success" and _is_empty_tool_output(tu.get("output", ""))
+        )
+        successful_tools = total_tools - failed_tools - empty_tools
+
+        if total_tools == 0:
+            lines.append(f"- **{agent_id}**: No tools were called. Sub-agent may have failed to start.")
+        elif successful_tools == 0:
+            lines.append(
+                f"- **{agent_id}**: ALL {total_tools} tool calls returned errors ({failed_tools}) or empty data ({empty_tools}). "
+                f"This sub-agent produced NO usable data. Confidence MUST be capped at 50% max."
+            )
+        elif failed_tools > 0 or empty_tools > 0:
+            lines.append(
+                f"- **{agent_id}**: {successful_tools}/{total_tools} tools returned usable data. "
+                f"{failed_tools} failed, {empty_tools} returned empty/zero results."
+            )
+        else:
+            lines.append(f"- **{agent_id}**: {successful_tools}/{total_tools} tools returned usable data.")
+
+    return "\n".join(lines)
+
+
+def _is_empty_tool_output(output: str) -> bool:
+    """Check if a tool output is effectively empty (zero data / errors only)."""
+    if not output or len(output) < 20:
+        return True
+    try:
+        data = json.loads(output)
+        if isinstance(data, dict):
+            # NRQL results with count: 0
+            results = data.get("results", [])
+            if results and all(r.get("count", -1) == 0 for r in results if isinstance(r, dict)):
+                return True
+            # NRQL TIMESERIES results where all data points are zero/null
+            timeseries = data.get("timeSeries") or data.get("totalResult", {}).get("timeSeries")
+            if not timeseries and isinstance(results, list) and results:
+                # Check if results is a list of time-bucketed data (TIMESERIES format)
+                # Each bucket looks like {"beginTimeSeconds": ..., "endTimeSeconds": ..., "throughput": 0, ...}
+                if all(isinstance(r, dict) and "beginTimeSeconds" in r for r in results[:3]):
+                    # Check if ALL numeric values across ALL buckets are 0 or null
+                    all_zero = True
+                    for r in results:
+                        for k, v in r.items():
+                            if k in ("beginTimeSeconds", "endTimeSeconds", "inspectedCount"):
+                                continue
+                            if isinstance(v, (int, float)) and v != 0:
+                                all_zero = False
+                                break
+                            if isinstance(v, dict):
+                                # Nested results like percentile: {"50": 0, "95": 0, "99": 0}
+                                if any(isinstance(sv, (int, float)) and sv != 0 for sv in v.values()):
+                                    all_zero = False
+                                    break
+                        if not all_zero:
+                            break
+                    if all_zero and len(results) > 0:
+                        return True
+            # Empty entity
+            if data.get("entity") == {}:
+                return True
+            # Only errors, no results
+            if data.get("errors") and not data.get("results"):
+                return True
+            # Empty Datapoints in CloudWatch response
+            if isinstance(data.get("Datapoints"), list) and len(data["Datapoints"]) == 0:
+                return True
+            # Empty events in CloudWatch Logs response
+            if isinstance(data.get("events"), list) and len(data["events"]) == 0:
+                return True
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return False
+
+
 def _gen_id() -> str:
-    import uuid
     return str(uuid.uuid4())

--- a/agent_service/agent/orchestrator.py
+++ b/agent_service/agent/orchestrator.py
@@ -120,6 +120,12 @@ async def orchestrate(request: AgentRunRequest) -> AsyncGenerator[str, None]:
         if incident_desc:
             ctx.generate_investigation_plan(incident_desc)
 
+    # Auto-resolve resource scope from user message before first dispatch
+    if not ctx.resources and request.resource_maps and user_messages:
+        last_user_msg = user_messages[-1].content if user_messages else ""
+        if last_user_msg:
+            _auto_resolve_resource_scope(last_user_msg, request.resource_maps, ctx)
+
     # Create sub-agents
     domain_integrations = [i for i in enabled_integrations if i != "github"]
     base_config = SubAgentConfig(
@@ -172,7 +178,7 @@ async def _run_orchestrator(
 ) -> AsyncGenerator[str, None]:
     now = datetime.now(timezone.utc)
     orchestrator_prompt = _build_orchestrator_prompt(
-        now, sub_agents, enabled_integrations, resource_maps,
+        now, sub_agents, enabled_integrations, resource_maps, ctx,
     )
 
     # Build input items from conversation history (only text messages)
@@ -202,9 +208,17 @@ async def _run_orchestrator(
     if is_follow_up:
         ctx_msg = ctx.build_context_message()
         if ctx_msg:
+            follow_up_directive = (
+                "\n\n[Follow-Up Query — IMPORTANT]\n"
+                "This is a follow-up message in an ongoing investigation. All resources have already been discovered.\n"
+                "- If the answer is already in the conversation, respond directly WITHOUT dispatching.\n"
+                "- If you must dispatch, use ONLY the single most relevant agent.\n"
+                "- Tell the agent to skip all discovery steps (list orgs, list projects, describe instances) "
+                "and query directly using the known resource names/IDs above."
+            )
             input_items.insert(0, {
                 "role": "developer",
-                "content": f"[Persisted Investigation Context — maintain this time window unless the user explicitly changes it]\n{ctx_msg}",
+                "content": f"[Persisted Investigation Context — maintain this time window unless the user explicitly changes it]\n{ctx_msg}{follow_up_directive}",
             })
 
     # Internal tools
@@ -212,11 +226,13 @@ async def _run_orchestrator(
     dispatch_tool = _build_dispatch_tool(available_agent_ids)
     evaluate_tool = _build_evaluate_tool()
     has_resource_maps = len(resource_maps) > 0
-    internal_tools = (
-        [_build_get_connected_resources_tool(), dispatch_tool, evaluate_tool]
-        if has_resource_maps
-        else [dispatch_tool, evaluate_tool]
-    )
+    resources_already_resolved = bool(ctx.resources and ctx.scoped_group_name)
+
+    # Skip _get_connected_resources when resources were auto-resolved from user message
+    if has_resource_maps and not resources_already_resolved:
+        internal_tools = [_build_get_connected_resources_tool(), dispatch_tool, evaluate_tool]
+    else:
+        internal_tools = [dispatch_tool, evaluate_tool]
 
     total_tokens = {"input": 0, "output": 0}
 
@@ -301,6 +317,11 @@ async def _run_orchestrator(
         # ── Run sub-agents ────────────────────────────────────
         if iteration == 0:
             active_call_id = first_dispatch_call["call_id"]
+
+        # Enrich tasks with known resource context for follow-ups
+        if is_follow_up:
+            assignments = _enrich_follow_up_tasks(assignments, ctx)
+
         results = []
 
         for assignment in assignments:
@@ -389,6 +410,17 @@ async def _run_orchestrator(
             input_items.append({
                 "role": "developer",
                 "content": 'This is the last orchestrator iteration. Strongly consider marking as "complete" unless critical data is clearly missing.',
+            })
+
+        # For follow-up data queries, hint that single-dispatch is often sufficient
+        if is_follow_up and iteration == 0:
+            input_items.append({
+                "role": "developer",
+                "content": (
+                    "[Follow-up evaluation hint] This is a follow-up query. If the sub-agent returned "
+                    "the specific data the user asked about, mark as complete with high confidence. "
+                    "Follow-up data queries do NOT require multi-agent investigation."
+                ),
             })
 
         evaluation = await _evaluate(client, model, input_items, orchestrator_prompt, internal_tools, total_tokens, results)
@@ -1171,6 +1203,126 @@ def _build_get_connected_resources_tool() -> dict[str, Any]:
 
 # ── Resource map helpers ──────────────────────────────────────
 
+def _auto_resolve_resource_scope(
+    user_message: str,
+    resource_maps: list[ResourceMap],
+    ctx: InvestigationContext,
+) -> None:
+    """Try to match user message content against resource map nodes/groups.
+
+    Extracts candidate service names from:
+    - PagerDuty URL path segments (e.g., /incidents/P1234ABC)
+    - Quoted strings in the message
+    - Word tokens that might be service/resource names
+
+    On match: populates ctx.resources and calls ctx.scope_to_resources().
+    """
+    import re as _re
+    candidates: list[str] = []
+
+    # Extract from PagerDuty URLs — check resource map nodes with source == "pagerduty"
+    pd_url_match = _re.search(r"pagerduty\.com/incidents/([A-Z0-9]+)", user_message, _re.IGNORECASE)
+    if pd_url_match:
+        # The incident ID itself won't match, but scan PD nodes for service name matches
+        for rmap in resource_maps:
+            for node in rmap.nodes:
+                if node.source == "pagerduty" and node.name:
+                    candidates.append(node.name)
+
+    # Extract quoted strings
+    for m in _re.findall(r'"([^"]{2,60})"', user_message):
+        candidates.append(m)
+    for m in _re.findall(r"'([^']{2,60})'", user_message):
+        candidates.append(m)
+
+    # Extract service-like tokens (words with hyphens/underscores that look like identifiers)
+    for m in _re.findall(r'\b([a-zA-Z][a-zA-Z0-9_-]{2,40})\b', user_message):
+        # Skip common non-service words
+        if m.lower() in {"the", "and", "for", "this", "that", "what", "how", "why",
+                         "are", "was", "were", "been", "has", "have", "had", "can",
+                         "could", "would", "should", "will", "with", "from", "into",
+                         "about", "which", "there", "their", "here", "some", "any",
+                         "investigate", "check", "look", "help", "please", "thanks",
+                         "https", "http", "com", "org", "net", "incidents", "pagerduty"}:
+            continue
+        candidates.append(m)
+
+    if not candidates:
+        return
+
+    # Try to match each candidate against resource map nodes/groups
+    for candidate in candidates:
+        normalized_candidate = normalize_name(candidate)
+        if not normalized_candidate or len(normalized_candidate) < 3:
+            continue
+
+        for rmap in resource_maps:
+            if not rmap.groups:
+                continue
+
+            node_by_id = {n.id: n for n in rmap.nodes}
+
+            # Pass 1: exact normalized name match on nodes
+            matched_node = next(
+                (n for n in rmap.nodes if n.normalizedName == normalized_candidate), None
+            )
+
+            # Pass 2: substring containment on nodes
+            if not matched_node:
+                matched_node = next(
+                    (n for n in rmap.nodes
+                     if normalized_candidate in n.normalizedName or n.normalizedName in normalized_candidate),
+                    None,
+                )
+
+            # Pass 3: group name match
+            if not matched_node:
+                for group in rmap.groups:
+                    ng = normalize_name(group.name)
+                    if ng == normalized_candidate or normalized_candidate in ng or ng in normalized_candidate:
+                        nodes = [node_by_id[nid] for nid in group.nodeIds if nid in node_by_id]
+                        if nodes:
+                            _apply_resource_scope(nodes, group.name, ctx)
+                            logger.info(
+                                "Auto-resolved resource scope from user message: group='%s' (%d resources)",
+                                group.name, len(nodes),
+                            )
+                            return
+                continue
+
+            # Find group containing matched node
+            for group in rmap.groups:
+                if matched_node.id in group.nodeIds:
+                    nodes = [node_by_id[nid] for nid in group.nodeIds if nid in node_by_id]
+                    if nodes:
+                        _apply_resource_scope(nodes, group.name, ctx)
+                        logger.info(
+                            "Auto-resolved resource scope from user message: matched node='%s', group='%s' (%d resources)",
+                            matched_node.name, group.name, len(nodes),
+                        )
+                        return
+
+
+def _apply_resource_scope(
+    nodes: list[ResourceNode],
+    group_name: str,
+    ctx: InvestigationContext,
+) -> None:
+    """Populate ctx.resources from resource map nodes and scope the context."""
+    from .investigation_context import ResourceEntry
+
+    for node in nodes:
+        ctx._add_resource(ResourceEntry(
+            name=node.name,
+            type=node.type,
+            id=node.externalId,
+            attrs=node.attrs,
+        ))
+
+    resource_names = [n.name for n in nodes]
+    ctx.scope_to_resources(resource_names, group_name)
+
+
 def _resolve_resource_scope(
     connected_call: Any,
     resource_maps: list[ResourceMap],
@@ -1244,6 +1396,7 @@ def _build_orchestrator_prompt(
     sub_agents: dict[SubAgentType, BaseSubAgent],
     enabled_integrations: list[str],
     resource_maps: list[ResourceMap],
+    ctx: InvestigationContext | None = None,
 ) -> str:
     agent_descs: dict[SubAgentType, str] = {
         "apm": "Queries New Relic for APM metrics, throughput, error rates, response times, transaction traces, and NRQL analytics",
@@ -1258,7 +1411,22 @@ def _build_orchestrator_prompt(
     )
 
     resource_section = ""
-    if resource_maps:
+    resources_pre_resolved = ctx and ctx.resources and ctx.scoped_group_name
+    if resources_pre_resolved:
+        resource_lines = [
+            f"\n\n## Resource Scope (Pre-resolved: {ctx.scoped_group_name})",  # type: ignore[union-attr]
+            "",
+            "Resources have been automatically resolved from the user's message. "
+            "All sub-agents will receive these resources in their investigation context. "
+            "Do NOT call `_get_connected_resources` — scoping is already done.",
+            "",
+            "Resolved resources:",
+        ]
+        for r in ctx.resources:  # type: ignore[union-attr]
+            id_part = f" (id: {r.id})" if r.id else ""
+            resource_lines.append(f"- [{r.type}] {r.name}{id_part}")
+        resource_section = "\n".join(resource_lines)
+    elif resource_maps:
         resource_section = """
 
 ## Resource Map
@@ -1305,6 +1473,18 @@ For ANY message that requires fetching live data from monitoring systems — whe
 - Only dispatch to agents whose domain is relevant.
 - Include known context in the task: service names, time windows, error messages, resource IDs.
 - For follow-up dispatches, reference specific findings from earlier rounds.
+
+## Follow-Up Query Handling
+
+When this is a follow-up message in an ongoing conversation (previous assistant responses exist):
+
+1. **Answer from context first.** If previous sub-agent findings already contain the answer, respond directly — do NOT dispatch.
+2. **Single-agent dispatch.** Follow-up data queries (counts, specific metrics, status checks) need at most ONE sub-agent. Dispatch to ONLY the single most relevant agent.
+3. **Specific task descriptions.** Include all known context in the dispatch task:
+   - Exact resource names and IDs from the investigation context (e.g., specific RDS instance names, log group paths, Sentry project slugs, New Relic entity GUIDs)
+   - The specific metric, count, or data point the user is asking about
+   - Explicit instruction: "Resources are already discovered in the investigation context — query directly without re-discovery."
+4. **No re-investigation.** A follow-up like "how many X errors?" or "what are the slow queries?" should NOT trigger a multi-agent investigation. It needs a single targeted query to one agent.
 
 Connected integrations: {', '.join(enabled_integrations)}
 Current time: {now.isoformat()}{resource_section}"""
@@ -1418,6 +1598,61 @@ def _build_data_quality_summary(results: list[Any] | None) -> str:
             lines.append(f"- **{agent_id}**: {successful_tools}/{total_tools} tools returned usable data.")
 
     return "\n".join(lines)
+
+
+def _enrich_follow_up_tasks(
+    assignments: list[dict[str, str]],
+    ctx: InvestigationContext,
+) -> list[dict[str, str]]:
+    """Enrich dispatch tasks with known resource context for follow-up queries.
+
+    Appends discovered resource names/IDs and a skip-discovery directive so
+    sub-agents don't waste tool calls re-discovering what's already known.
+    """
+    if not ctx.resources:
+        return assignments
+
+    # Map agent types to relevant resource types
+    agent_resource_types: dict[str, list[str]] = {
+        "infrastructure": ["rds", "ec2", "lambda", "log_group"],
+        "error_monitoring": ["sentry_project"],
+        "apm": ["newrelic_app"],
+        "alerting": [],  # PagerDuty doesn't need resource enrichment
+    }
+
+    enriched = []
+    for a in assignments:
+        agent_id = a["agentId"]
+        task = a["task"]
+
+        relevant_types = agent_resource_types.get(agent_id, [])
+        relevant = [r for r in ctx.resources if r.type in relevant_types]
+
+        if relevant:
+            lines = []
+            for r in relevant:
+                id_part = f" (id: {r.id})" if r.id else ""
+                useful_attrs = {k: v for k, v in r.attrs.items() if v and k not in ("name",)}
+                attr_str = f" [{', '.join(f'{k}={v}' for k, v in useful_attrs.items())}]" if useful_attrs else ""
+                lines.append(f"  - [{r.type}] {r.name}{id_part}{attr_str}")
+
+            task += (
+                "\n\nKnown resources (DO NOT re-discover — use these directly):\n"
+                + "\n".join(lines)
+                + "\n\nSkip all discovery steps (list orgs, list projects, describe instances). "
+                "Query the data directly using the resource names/IDs above."
+            )
+
+        # Add entity names for the relevant platform
+        entity_map = {"apm": "newrelic", "error_monitoring": "sentry", "alerting": "pagerduty"}
+        platform = entity_map.get(agent_id)
+        if platform and platform in ctx.entities:
+            names = ctx.entities[platform]
+            task += f"\n\nKnown {platform} entities: {', '.join(names)}"
+
+        enriched.append({"agentId": agent_id, "task": task})
+
+    return enriched
 
 
 def _is_empty_tool_output(output: str) -> bool:

--- a/agent_service/agent/prompts/__init__.py
+++ b/agent_service/agent/prompts/__init__.py
@@ -118,7 +118,7 @@ GUIDANCE_AWS = """**AWS Reference (via AWS API MCP — uses AWS CLI commands):**
 **Database Investigation (MANDATORY when RDS/databases are in scope):**
 - Key RDS CloudWatch metrics: CPUUtilization, DatabaseConnections, FreeableMemory, ReadLatency, WriteLatency, ReadIOPS, WriteIOPS, DiskQueueDepth, SwapUsage
 - Connection exhaustion: Compare DatabaseConnections against the instance's max_connections limit
-- Performance Insights: Use `pi get-resource-metrics` with the DbiResourceId to get top SQL queries and wait events during the incident window
+- Performance Insights: Use `pi describe-dimension-keys` with Metric=`db.load` and GroupBy Group=`db.sql_tokenized` to find top SQL. Use `pi get-resource-metrics` with Metric=`db.load` and GroupBy Group=`db.sql_tokenized` for load timeseries. Valid GroupBy Groups: `db.sql`, `db.sql_tokenized`, `db.host`, `db.application`, `db.session_type`, `db.user`. WARNING: `db.wait_event` and `db.wait_state` are Metrics, NOT GroupBy Groups
 - Slow query logs: Check CloudWatch Logs group `/aws/rds/instance/<name>/slowquery` for queries during the incident
 - Always compare incident-window metrics against baseline (period before the incident) to identify what changed
 

--- a/agent_service/agent/prompts/__init__.py
+++ b/agent_service/agent/prompts/__init__.py
@@ -46,13 +46,15 @@ Scale your response to the task:
 **Investigations** (error diagnosis, incident analysis, performance issues) — structured diagnosis:
 
 - **What's Happening** — 1-2 sentence summary with specific numbers
-- **Error Details** — exact error messages, stack trace frames, frequency, affected users
+- **Error Details** — exact error messages, stack trace frames, frequency during the incident window (NOT total/lifetime counts), affected users
+- **Log Patterns** — error log spikes, unusual log messages, new error patterns discovered in logs during the incident window
+- **Database Impact** — connection counts, query latency, slow queries, Performance Insights findings (when databases are involved)
 - **Code Analysis** — the relevant code snippet, when it was last changed, what's wrong, suggested fix
-- **Performance Impact** — response time, error rate, throughput (before → now)
-- **Infrastructure** — CloudWatch alarms, resource utilization
+- **Performance Impact** — response time, error rate, throughput (before → during incident comparison)
+- **Infrastructure** — CloudWatch alarms, resource utilization changes
 - **Incident Status** — PagerDuty incidents, who's responding
 - **Timeline** — chronological events across all sources
-- **Root Cause** — definitive explanation connecting all evidence
+- **Root Cause** — definitive explanation connecting errors + logs + metrics + infrastructure
 
 Be direct and specific. Engineers want data, not prose. Always include actual numbers, timestamps, and error messages."""
 
@@ -66,17 +68,44 @@ CORRELATION = """You have both error tracking and performance monitoring connect
 
 GUIDANCE_NEWRELIC = """**New Relic Reference (3 tools):**
 - **nr_list_entities** — Discover app names and GUIDs first. Names differ across platforms. Use entity search queries like `domain = 'APM' AND name LIKE 'payment'`.
-- **nr_run_nrql** — Execute any NRQL query. Time syntax: `SINCE 1 hour ago`, `SINCE '2024-01-15 14:00:00' UNTIL '2024-01-15 15:00:00'`. Use FACET for breakdowns, TIMESERIES for trends. Covers Transaction, TransactionError, Log, Metric, Span, and all event types.
+- **nr_run_nrql** — Execute any NRQL query. Use FACET for breakdowns, TIMESERIES for trends. Covers Transaction, TransactionError, Log, Metric, Span, and all event types.
 - **nr_get_entity_golden_metrics** — Get golden signals, recent alerts, deployments, and related entities for a GUID from nr_list_entities.
 - Apdex < 0.85 = degraded user experience.
-- New Relic URLs contain an opaque `state` parameter you cannot decode — extract the `account` query param and ask the engineer what they see on the page."""
+- New Relic URLs contain an opaque `state` parameter you cannot decode — extract the `account` query param and ask the engineer what they see on the page.
+
+**NRQL Time Syntax (CRITICAL — follow exactly):**
+- **Relative time (preferred for recent incidents):** `SINCE 4 hours ago`, `SINCE 1 day ago UNTIL 22 hours ago`
+- **Absolute timestamps — MUST be single-quoted UTC, NO timezone offsets:**
+  - CORRECT: `SINCE '2024-01-15 14:00:00' UNTIL '2024-01-15 15:00:00'`
+  - WRONG: `SINCE 2024-01-15T14:00:00+05:30` — timezone offsets cause syntax errors
+  - WRONG: `SINCE 2024-01-15 14:00:00` — unquoted timestamps cause syntax errors
+- **For historical incidents** (not in the last few hours): Calculate relative offset from current time. If the incident was 24 hours ago and lasted 2 hours, use `SINCE 26 hours ago UNTIL 24 hours ago`.
+- **Never use `apdex()` without arguments** — use `apdex(duration, t: 0.5)` instead.
+
+**Log Analysis (MANDATORY during investigations):**
+You MUST query logs during any investigation. Logs reveal patterns that metrics alone cannot.
+- Error log spike: `FROM Log SELECT count(*) WHERE level IN ('ERROR', 'FATAL', 'WARN') FACET level TIMESERIES SINCE <window>`
+- Error patterns by message: `FROM Log SELECT count(*) WHERE level = 'ERROR' FACET message LIMIT 20 SINCE <window>`
+- New/unusual errors: `FROM Log SELECT uniques(message, 25) WHERE level = 'ERROR' SINCE <window>`
+- DB-related logs: `FROM Log SELECT count(*), latest(message) WHERE message LIKE '%timeout%' OR message LIKE '%connection refused%' OR message LIKE '%deadlock%' OR message LIKE '%slow query%' FACET message SINCE <window>`
+- Exception traces: `FROM Log SELECT count(*) WHERE message LIKE '%Exception%' OR message LIKE '%Traceback%' FACET message LIMIT 20 SINCE <window>`
+- Log volume anomaly: `FROM Log SELECT count(*) FACET level TIMESERIES SINCE <window> COMPARE WITH 1 day ago`
+
+**Database & External Service Metrics (check during investigations):**
+- Datastore latency: `FROM Metric SELECT average(apm.service.datastore.operation.duration) FACET datastoreType, operation TIMESERIES SINCE <window>`
+- External call latency: `FROM Metric SELECT average(apm.service.external.host.duration) FACET external.host TIMESERIES SINCE <window>`
+- DB query breakdown: `FROM Span SELECT average(duration) WHERE category = 'datastore' FACET db.statement LIMIT 10 SINCE <window>`"""
 
 GUIDANCE_SENTRY = """**Sentry Reference:**
-- The Sentry tools do NOT accept time-range parameters — they return recent issues/events without date filtering. Results include `firstSeen` and `lastSeen` timestamps on each issue.
+- The Sentry tools do NOT accept time-range parameters — they return recent issues/events without date filtering.
+- **CRITICAL: Always filter by time window.** Each issue has `firstSeen` and `lastSeen` timestamps. Compare these against the investigation time window:
+  - **NEW during window**: `firstSeen` is within the investigation window — this error started during the incident. High priority.
+  - **ACTIVE during window**: `firstSeen` is before the window but `lastSeen` is within it — recurring error still firing.
+  - **IRRELEVANT**: `lastSeen` is before the investigation window — skip this issue entirely. Do NOT report it.
+- **Never report total/lifetime event counts.** Total counts span the entire lifetime of an issue and are misleading. Focus on whether the issue is NEW or RECURRING relative to the investigation time window, and use `firstSeen`/`lastSeen` to establish a timeline.
 - Project slugs may differ from service names in other platforms (e.g., "payment_api" vs "payment-api" vs "Payment API").
-- `firstSeen` indicates whether an error is new (likely from a recent deploy).
-- Stack traces provide exact file:line references.
-- Error frequency + affected user count indicate severity."""
+- Stack traces provide exact file:line references — always retrieve them for the most relevant issues.
+- Look for error clusters: multiple different errors with `firstSeen` around the same time often share a root cause (e.g., a bad deploy, a DB going down, a config change)."""
 
 GUIDANCE_AWS = """**AWS Reference (via AWS API MCP — uses AWS CLI commands):**
 - READ-ONLY investigation. Always include `--region` and `--output json` in every command.
@@ -84,7 +113,23 @@ GUIDANCE_AWS = """**AWS Reference (via AWS API MCP — uses AWS CLI commands):**
 - Use `suggest_aws_commands` if unsure what CLI command to use.
 - Performance Insights `--identifier` must be `DbiResourceId` (e.g. `db-XXXX`), not the instance name.
 - CloudWatch `--period`: 300 default, 60 for recent incidents.
-- Use resource names/IDs from the investigation context — do not re-discover resources already listed there."""
+- Use resource names/IDs from the investigation context — do not re-discover resources already listed there.
+
+**Database Investigation (MANDATORY when RDS/databases are in scope):**
+- Key RDS CloudWatch metrics: CPUUtilization, DatabaseConnections, FreeableMemory, ReadLatency, WriteLatency, ReadIOPS, WriteIOPS, DiskQueueDepth, SwapUsage
+- Connection exhaustion: Compare DatabaseConnections against the instance's max_connections limit
+- Performance Insights: Use `pi get-resource-metrics` with the DbiResourceId to get top SQL queries and wait events during the incident window
+- Slow query logs: Check CloudWatch Logs group `/aws/rds/instance/<name>/slowquery` for queries during the incident
+- Always compare incident-window metrics against baseline (period before the incident) to identify what changed
+
+**CloudWatch Logs Investigation (MANDATORY during investigations):**
+- Use `logs filter-log-events` with `--filter-pattern` to search for specific patterns
+- Error patterns: `--filter-pattern "ERROR"`, `--filter-pattern "Exception"`, `--filter-pattern "FATAL"`
+- Connection issues: `--filter-pattern "timeout"`, `--filter-pattern "connection refused"`, `--filter-pattern "ECONNREFUSED"`
+- **PostgreSQL slow queries**: Use `--filter-pattern "duration"` (PostgreSQL logs slow queries as `LOG: duration: 1234.567 ms`). Do NOT search for "slow" — PostgreSQL does not use that word.
+- Also useful for PostgreSQL: `--filter-pattern "canceling statement"` (for statement timeout cancellations)
+- Always scope to the investigation time window with `--start-time` and `--end-time` (epoch milliseconds)
+- Check multiple log groups: application logs, database logs, load balancer access logs"""
 
 GUIDANCE_GITHUB = """**GitHub Reference:**
 - Use blame on error-related files to check for recent changes — recent changes are the #1 cause of new production errors.
@@ -98,11 +143,21 @@ GUIDANCE_PAGERDUTY = """**PagerDuty Reference:**
 - Incident `created_at` timestamp defines the incident time window for cross-referencing other tools.
 - Incident descriptions often contain error messages or service names searchable in other tools."""
 
-NUDGE_ITERATION_0 = "You have initial results. If the user asked a simple data question (status check, listing resources, fetching metrics) and the data was returned successfully, produce the final answer now. Otherwise, extract identifiers from what you got (service names, timestamps, error messages, resource IDs) and use them to query other connected sources. Fix and retry any failed tool calls. Keep investigating."
+CORRELATION_ANALYSIS = """You are analyzing findings from multiple investigation agents across different monitoring domains. Your job is to identify causal relationships and temporal correlations.
 
-NUDGE_ITERATION_1 = "You have error and metric data. Drill deeper: if you have stack traces, read the source code. Cross-reference identifiers across platforms. Fix any queries that returned empty or errored — adjust parameters and retry. Keep investigating."
+Given these findings from different domains, identify:
+1. **Causal chains**: Which finding likely caused which? (e.g., DB CPU spike → query cancellations → application errors → user-facing 500s)
+2. **Temporal correlations**: Events that happened around the same time across different systems
+3. **Root cause**: The most likely root cause that explains all the observed symptoms
+4. **Impact chain**: How the root cause propagated through the system
 
-NUDGE_ITERATION_2 = "You have substantial data. If you have stack traces but haven't read the source code, do it now. Correlate all findings into a coherent timeline. Produce your final diagnosis with specific data."
+Be specific. Reference actual error messages, metric values, and timestamps from the findings. Produce a concise correlation summary (3-5 sentences) connecting the dots across all domains."""
+
+NUDGE_ITERATION_0 ="You have initial results. If the user asked a simple data question (status check, listing resources, fetching metrics) and the data was returned successfully, produce the final answer now. Otherwise: (1) Extract identifiers from what you got (service names, timestamps, error messages, resource IDs). (2) Query LOGS for error patterns and anomalies during the time window — this is mandatory, not optional. (3) Check database metrics if any databases are in scope. (4) Fix and retry any failed tool calls. Surface-level data (just listing errors or getting high-level counts) is NOT enough."
+
+NUDGE_ITERATION_1 = "You have initial data. Now go deeper: (1) If you haven't queried LOGS yet, do it now — look for error log spikes, new error patterns, and unusual log messages during the time window. (2) If databases are involved, check RDS metrics (connections, latency, CPU), slow queries via Performance Insights, and DB-related log entries. (3) If you have stack traces, read the source code. (4) Cross-reference identifiers across platforms. Fix any failed queries."
+
+NUDGE_ITERATION_2 = "You have substantial data. Before finishing, verify completeness: (1) Did you check LOGS for patterns? If not, do it now. (2) Did you check database health if databases are connected? If not, query DB metrics. (3) Did you filter Sentry results by the investigation time window (not total counts)? (4) Correlate all findings into a coherent timeline with specific numbers. Produce your final diagnosis connecting errors → logs → metrics → infrastructure."
 
 EVALUATION_SYSTEM = """You are evaluating the progress of an SRE agent's work. Based on the conversation history and tool results gathered so far, produce a JSON assessment.
 
@@ -110,15 +165,24 @@ First, determine the type of request:
 
 **Data queries** (status checks, listing resources, fetching metrics, reading current state): If the user asked a straightforward data question — not diagnosing a problem — and the sub-agent successfully returned the requested data, mark as `complete` with high confidence (80+). The data was fetched and can be presented. No need for stack traces, root cause, or multi-source correlation.
 
-**Investigations** (error diagnosis, incident analysis, performance degradation): Evaluate whether the investigation has enough data to deliver a concrete, evidence-based diagnosis. A complete investigation has:
-- Specific error messages and stack traces (not just counts)
-- Metrics with actual numbers (response times, error rates, throughput)
-- Root cause identification backed by evidence
-- Code-level analysis where stack traces are available
+**Investigations** (error diagnosis, incident analysis, performance degradation): Evaluate whether the investigation has enough data to deliver a concrete, evidence-based diagnosis. A complete investigation MUST have:
+- Specific error messages and stack traces (not just counts or summaries)
+- Metrics with actual numbers (response times, error rates, throughput) scoped to the incident time window
+- **Log analysis**: Error log patterns, log volume anomalies, and unusual log messages during the incident window. If logs haven't been queried, the investigation is NOT complete.
+- **Database investigation** (when databases are in scope): DB metrics (connections, latency, slow queries). If databases are connected but not investigated, the investigation is NOT complete.
+- Root cause identification backed by evidence from multiple signals (errors + logs + metrics)
 - Timeline of events across sources
 - Cross-referenced data from multiple platforms where applicable
 
-For investigations, be strict: surface-level data (just listing apps or getting high-level counts) is NOT complete. The investigation must drill into the specifics. If fewer than 2 tool calls have been made for an investigation, return status "continue".
+For investigations, be strict:
+- Surface-level data (just listing errors or getting high-level counts) is NOT complete — confidence should be below 30.
+- Having errors but no log analysis is NOT complete — logs reveal patterns metrics cannot.
+- Having metrics but no database investigation (when DBs are in scope) is NOT complete.
+- Reporting total/lifetime Sentry event counts instead of time-windowed analysis is NOT complete.
+- If fewer than 3 tool calls have been made for an investigation, return status "continue".
+- **Sub-agent failures are NOT acceptable**: If a sub-agent was dispatched but ALL its tool calls returned errors, syntax failures, or zero results, the investigation is NOT complete. The sub-agent must be re-dispatched with corrected parameters. Do NOT accept "no data available" when the data source exists but queries failed.
+- **Zero APM/metric data when APM is connected**: If APM was queried but returned only errors or empty results (count: 0), this is a query failure, not a valid finding. Recommend re-dispatching with corrected query syntax. Confidence should be capped at 50% in this case.
+- **Unscoped Sentry results**: If Sentry returned 100 issues without time filtering, the investigation is NOT complete — results must be scoped to the incident time window.
 
 Produce your output as a JSON object with these fields:
 - status: "continue" or "complete"

--- a/agent_service/agent/sub_agents/apm.py
+++ b/agent_service/agent/sub_agents/apm.py
@@ -23,14 +23,30 @@ class APMAgent(BaseSubAgent):
             patterns.append("nr_")
         return patterns
 
+    def get_excluded_tool_patterns(self, task: str) -> list[str]:
+        excluded = []
+        ctx = self.config.investigation_context
+        has_nr_apps = any(r.type == "newrelic_app" for r in ctx.resources)
+        if has_nr_apps:
+            excluded.append("nr_list_entities")
+        return excluded
+
     def get_own_tools(self) -> list[dict[str, Any]]:
         return self.get_registry_tools_by_category("newrelic")
 
     def get_system_prompt(self) -> str:
+        ctx = self.config.investigation_context
+        has_nr_apps = any(r.type == "newrelic_app" for r in ctx.resources)
+        discovery_rule = (
+            "1. Use the New Relic app names and GUIDs from the investigation context — do NOT call nr_list_entities."
+            if has_nr_apps
+            else "1. Discover application names first — names may differ across platforms."
+        )
+
         return f"""You are an APM investigation agent specializing in New Relic data. Your job is to query New Relic for application performance, error rates, throughput, response times, **log patterns**, and **database performance** — all scoped to the investigation time window.
 
 # Core Rules
-1. Discover application names first — names may differ across platforms.
+{discovery_rule}
 2. Use NRQL queries to get specific metrics with exact numbers, always scoped to the investigation time window.
 3. **Always query logs** — this is mandatory, not optional. Logs reveal error patterns, unusual messages, and anomalies that metrics alone cannot show.
 4. **Always check database/datastore metrics** when databases are in scope — query latency, slow operations, and connection patterns.

--- a/agent_service/agent/sub_agents/apm.py
+++ b/agent_service/agent/sub_agents/apm.py
@@ -11,6 +11,7 @@ from ..prompts import GUIDANCE_NEWRELIC
 class APMAgent(BaseSubAgent):
     agent_id = "apm"  # type: ignore[assignment]
     agent_type = "APM Agent"
+    shared_integrations = ["github"]
 
     def __init__(self, config: SubAgentConfig) -> None:
         super().__init__(config)

--- a/agent_service/agent/sub_agents/apm.py
+++ b/agent_service/agent/sub_agents/apm.py
@@ -16,29 +16,46 @@ class APMAgent(BaseSubAgent):
     def __init__(self, config: SubAgentConfig) -> None:
         super().__init__(config)
 
+    def get_required_tool_patterns(self, task: str) -> list[str]:
+        task_lower = task.lower()
+        patterns = ["newrelic"]  # Always require at least one NR call
+        if any(kw in task_lower for kw in ["metric", "throughput", "error rate", "response time", "golden"]):
+            patterns.append("nr_")
+        return patterns
+
     def get_own_tools(self) -> list[dict[str, Any]]:
         return self.get_registry_tools_by_category("newrelic")
 
     def get_system_prompt(self) -> str:
-        return f"""You are an APM investigation agent specializing in New Relic data. Your job is to query New Relic for application performance metrics, error rates, throughput, response times, and transaction traces.
+        return f"""You are an APM investigation agent specializing in New Relic data. Your job is to query New Relic for application performance, error rates, throughput, response times, **log patterns**, and **database performance** — all scoped to the investigation time window.
 
 # Core Rules
 1. Discover application names first — names may differ across platforms.
-2. Use NRQL queries to get specific metrics with exact numbers.
-3. Look at transaction traces for slow code paths.
-4. Get error rates, throughput, and response time trends.
+2. Use NRQL queries to get specific metrics with exact numbers, always scoped to the investigation time window.
+3. **Always query logs** — this is mandatory, not optional. Logs reveal error patterns, unusual messages, and anomalies that metrics alone cannot show.
+4. **Always check database/datastore metrics** when databases are in scope — query latency, slow operations, and connection patterns.
 5. Always report specific numbers, not vague descriptions.
 6. If a tool call fails, fix parameters and retry immediately.
 
+# Investigation Sequence
+For any investigation, follow this sequence:
+1. **Discover entities** — Find the app name and GUID.
+2. **Golden metrics** — Get throughput, error rate, response time overview.
+3. **Error breakdown** — Query TransactionError for specific error messages and counts.
+4. **Log analysis** — Query logs for error patterns, unusual messages, and volume anomalies. This is NOT optional.
+5. **Database metrics** — Query datastore operation latency, slow queries, external call latency. Check if DB is a bottleneck.
+6. **Comparison** — Compare incident-window metrics against the period before to identify what changed.
+
 # Focus Areas
-- Application throughput (requests/min)
-- Error rates and top errors
-- Response time percentiles (p50, p95, p99)
+- Application throughput (requests/min) — incident window vs baseline
+- Error rates and top error messages (not just counts)
+- Response time percentiles (p50, p95, p99) — incident window vs baseline
+- **Log patterns**: error log spikes, new error messages, unusual log entries, DB-related log messages
+- **Database/datastore performance**: operation latency by type, slow queries, connection issues
 - Transaction traces for slow endpoints
 - Apdex scores (< 0.85 = degraded)
-- Application logs
 - Deployment markers and recent changes
 
 {GUIDANCE_NEWRELIC}
 
-Produce a concise findings summary with specific metrics and numbers when done."""
+Produce a concise findings summary with: (1) key metrics with before/during comparison, (2) log patterns and anomalies found, (3) database performance analysis, (4) specific error messages and their frequencies during the window."""

--- a/agent_service/agent/sub_agents/base.py
+++ b/agent_service/agent/sub_agents/base.py
@@ -62,6 +62,7 @@ class SubAgentConfig:
 class BaseSubAgent(ABC):
     agent_id: SubAgentType
     agent_type: str
+    shared_integrations: list[str] = []
 
     def __init__(self, config: SubAgentConfig) -> None:
         self.config = config
@@ -98,8 +99,9 @@ class BaseSubAgent(ABC):
     def get_tools(self) -> list[dict[str, Any]]:
         own = self.get_own_tools()
         shared: list[dict[str, Any]] = []
-        if "github" in self.config.enabled_integrations:
-            shared.extend(self.get_mcp_tools("github"))
+        for integration in self.shared_integrations:
+            if integration in self.config.enabled_integrations:
+                shared.extend(self.get_mcp_tools(integration))
         return [*own, *shared]
 
     # ── Run loop ──────────────────────────────────────────────

--- a/agent_service/agent/sub_agents/base.py
+++ b/agent_service/agent/sub_agents/base.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 from openai import AsyncOpenAI
@@ -13,7 +15,7 @@ from openai import AsyncOpenAI
 from ..integrations.mcp.client_manager import MCPClientManager
 from ..integrations.tool_registry import tool_registry
 from ..integrations.tool_context import ToolContext
-from ..investigation_context import InvestigationContext
+from ..investigation_context import InvestigationContext, CRITICAL_PATTERNS
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,36 @@ SubAgentType = Literal["apm", "error_monitoring", "infrastructure", "alerting"]
 
 MAX_SUB_AGENT_ITERATIONS = 5
 MAX_TOOL_RESULT_CHARS = 30_000
+
+# Patterns for secrets that should be redacted from tool output
+_SECRET_PATTERNS = [
+    # API keys and tokens with common prefixes
+    re.compile(r'(sk[-_][a-zA-Z0-9_-]{20,})'),                      # OpenAI, Stripe, etc.
+    re.compile(r'(ghp_[a-zA-Z0-9]{20,})'),                           # GitHub PAT
+    re.compile(r'(gho_[a-zA-Z0-9]{20,})'),                           # GitHub OAuth
+    re.compile(r'(ghu_[a-zA-Z0-9]{20,})'),                           # GitHub User
+    re.compile(r'(ghs_[a-zA-Z0-9]{20,})'),                           # GitHub Server
+    re.compile(r'(xoxb-[a-zA-Z0-9-]{20,})'),                         # Slack bot token
+    re.compile(r'(xoxp-[a-zA-Z0-9-]{20,})'),                         # Slack user token
+    re.compile(r'(AKIA[A-Z0-9]{16})'),                                # AWS access key
+    # Key-value patterns in JSON/env output
+    re.compile(r'("(?:API_KEY|SECRET_KEY|ACCESS_KEY|AUTH_TOKEN|PRIVATE_KEY|PASSWORD|SECRET|TOKEN|CREDENTIALS|GH_PAT|OPENAI_API_KEY|ELEVENLABS_API_KEY|DAILY_API_KEY|ANTHROPIC_API_KEY|STRIPE_SECRET_KEY|DATABASE_URL|REDIS_URL|SENTRY_DSN)"\s*:\s*")([^"]{8,})(")'),
+    # Master username/password in RDS output
+    re.compile(r'("MasterUserPassword"\s*:\s*")([^"]+)(")'),
+]
+
+
+def _redact_secrets(content: str) -> str:
+    """Redact known secret patterns from tool output."""
+    for pattern in _SECRET_PATTERNS:
+        groups = pattern.groups if hasattr(pattern, 'groups') else 0
+        if pattern.groups >= 3:
+            # Key-value pattern: preserve key, redact value
+            content = pattern.sub(r'\1[REDACTED]\3', content)
+        else:
+            # Direct token pattern: replace entire match
+            content = pattern.sub('[REDACTED]', content)
+    return content
 
 
 class SubAgentResult:
@@ -78,6 +110,94 @@ class BaseSubAgent(ABC):
         """Domain-specific system prompt."""
         ...
 
+    def get_required_tool_patterns(self, task: str) -> list[str]:
+        """Return tool name patterns that MUST be called given the task.
+
+        Override in sub-agents to enforce specific tools for specific tasks.
+        Returns empty list by default (no required tools).
+        """
+        return []
+
+    def _check_required_tools(self, task: str, all_tool_uses: list[dict[str, Any]]) -> list[str]:
+        """Check if required tools were called AND returned useful data.
+
+        Returns list of missing or failed tool pattern descriptions.
+        """
+        required = self.get_required_tool_patterns(task)
+        if not required:
+            return []
+
+        missing = []
+        for pattern in required:
+            pat_lower = pattern.lower()
+            # Find tools matching this pattern
+            matching_tools = [
+                tu for tu in all_tool_uses
+                if pat_lower in tu.get("name", "").lower()
+            ]
+
+            if not matching_tools:
+                missing.append(pattern)
+                continue
+
+            # Check if ALL matching tools failed or returned empty data
+            all_failed = all(
+                tu.get("status") == "error"
+                or self._is_empty_result(tu.get("output", ""))
+                for tu in matching_tools
+            )
+            if all_failed:
+                missing.append(f"{pattern} (called but returned errors/empty — retry with corrected parameters)")
+
+        return missing
+
+    @staticmethod
+    def _is_empty_result(output: str) -> bool:
+        """Check if a tool result is effectively empty (zero data)."""
+        if not output:
+            return True
+        # Check for common empty result patterns
+        try:
+            data = json.loads(output)
+            if isinstance(data, dict):
+                # NRQL results with count: 0
+                results = data.get("results", [])
+                if results and all(r.get("count", -1) == 0 for r in results if isinstance(r, dict)):
+                    return True
+                # NRQL TIMESERIES results where all data points are zero/null
+                if isinstance(results, list) and results:
+                    if all(isinstance(r, dict) and "beginTimeSeconds" in r for r in results[:3]):
+                        all_zero = True
+                        for r in results:
+                            for k, v in r.items():
+                                if k in ("beginTimeSeconds", "endTimeSeconds", "inspectedCount"):
+                                    continue
+                                if isinstance(v, (int, float)) and v != 0:
+                                    all_zero = False
+                                    break
+                                if isinstance(v, dict):
+                                    if any(isinstance(sv, (int, float)) and sv != 0 for sv in v.values()):
+                                        all_zero = False
+                                        break
+                            if not all_zero:
+                                break
+                        if all_zero and len(results) > 0:
+                            return True
+                # Empty entity response
+                if data.get("entity") == {}:
+                    return True
+                # All errors, no results
+                if data.get("errors") and not data.get("results"):
+                    return True
+                # Empty Datapoints / events
+                if isinstance(data.get("Datapoints"), list) and len(data["Datapoints"]) == 0:
+                    return True
+                if isinstance(data.get("events"), list) and len(data["events"]) == 0:
+                    return True
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return False
+
     # ── Tool helpers ──────────────────────────────────────────
 
     def get_mcp_tools(self, integration: str) -> list[dict[str, Any]]:
@@ -96,13 +216,37 @@ class BaseSubAgent(ABC):
     def get_registry_tools_by_category(self, category: str) -> list[dict[str, Any]]:
         return tool_registry.to_openai_tools_by_category(category)
 
-    def get_tools(self) -> list[dict[str, Any]]:
+    def get_excluded_tool_patterns(self, task: str) -> list[str]:
+        """Return tool name patterns to EXCLUDE given the task.
+
+        Override in sub-agents to filter out irrelevant tools.
+        Returns empty list by default (no exclusions).
+        """
+        return []
+
+    def get_tools(self, task: str = "") -> list[dict[str, Any]]:
         own = self.get_own_tools()
         shared: list[dict[str, Any]] = []
         for integration in self.shared_integrations:
             if integration in self.config.enabled_integrations:
                 shared.extend(self.get_mcp_tools(integration))
-        return [*own, *shared]
+        all_tools = [*own, *shared]
+
+        # Filter out excluded tools based on task context
+        excluded = self.get_excluded_tool_patterns(task)
+        if excluded:
+            filtered = [
+                t for t in all_tools
+                if not any(pat in t.get("name", "").lower() for pat in excluded)
+            ]
+            if len(filtered) < len(all_tools):
+                logger.info(
+                    "Filtered %d tools from %s (excluded patterns: %s)",
+                    len(all_tools) - len(filtered), self.agent_id, excluded,
+                )
+            return filtered
+
+        return all_tools
 
     # ── Run loop ──────────────────────────────────────────────
 
@@ -115,7 +259,7 @@ class BaseSubAgent(ABC):
         client = self.config.client
         model = self.config.model
         ctx = self.config.investigation_context
-        tools = self.get_tools()
+        tools = self.get_tools(task)
         system_prompt = self.get_system_prompt()
 
         input_items: list[Any] = [{"role": "user", "content": task}]
@@ -130,8 +274,9 @@ class BaseSubAgent(ABC):
         all_tool_uses: list[dict[str, Any]] = []
         full_text = ""
         total_tokens = {"input": 0, "output": 0}
+        forced_extension_used = False
 
-        for iteration in range(MAX_SUB_AGENT_ITERATIONS):
+        for iteration in range(MAX_SUB_AGENT_ITERATIONS + 1):  # +1 for possible forced extension
             tool_choice = "required" if iteration == 0 and tools else "auto"
 
             response = await client.responses.create(
@@ -189,8 +334,22 @@ class BaseSubAgent(ABC):
                             "arguments": item.arguments,
                         })
 
-            # No function calls → done
+            # No function calls → done (but check required tools first)
             if not function_calls:
+                missing = self._check_required_tools(task, all_tool_uses)
+                if missing and not forced_extension_used:
+                    # Force one more iteration to call missing tools
+                    forced_extension_used = True
+                    logger.warning(
+                        "Sub-agent %s finished without calling required tools: %s. Forcing extension.",
+                        self.agent_id, missing,
+                    )
+                    input_items.append({
+                        "role": "developer",
+                        "content": f"You have NOT called the following required tools: {', '.join(missing)}. You MUST call them before finishing. This is mandatory for a complete investigation.",
+                    })
+                    continue
+
                 return SubAgentResult(
                     agent_id=self.agent_id,
                     findings=full_text,
@@ -251,6 +410,9 @@ class BaseSubAgent(ABC):
                 })
                 continue
 
+            # Intercept and validate tool args
+            tool_args = self._intercept_tool_args(tool_name, tool_args, integration)
+
             # Cache check
             cache_key = f"{tool_name}::{json.dumps(tool_args, sort_keys=True)}"
             cached = self._tool_cache.get(cache_key)
@@ -288,6 +450,12 @@ class BaseSubAgent(ABC):
 
                 execution_time = int((time.time() - start_time) * 1000)
 
+                # Redact secrets before any further processing
+                content = _redact_secrets(content)
+
+                # Post-process results (Sentry time filtering)
+                content = self._post_process_tool_result(tool_name, content, integration)
+
                 if len(content) > MAX_TOOL_RESULT_CHARS:
                     content = (
                         content[:MAX_TOOL_RESULT_CHARS]
@@ -297,7 +465,9 @@ class BaseSubAgent(ABC):
                 tw_start = ctx.time_window.get("start")
                 tw_end = ctx.time_window.get("end")
                 if tw_start and tw_end:
-                    content += f"\n\n[Investigation window: {tw_start.isoformat()} to {tw_end.isoformat()}]"
+                    utc_s = tw_start.astimezone(timezone.utc) if tw_start.tzinfo else tw_start.replace(tzinfo=timezone.utc)
+                    utc_e = tw_end.astimezone(timezone.utc) if tw_end.tzinfo else tw_end.replace(tzinfo=timezone.utc)
+                    content += f"\n\n[Investigation window: {utc_s.strftime('%Y-%m-%d %H:%M:%S')} UTC to {utc_e.strftime('%Y-%m-%d %H:%M:%S')} UTC]"
 
                 self._tool_cache[cache_key] = {"output": content, "executionTimeMs": execution_time}
 
@@ -315,6 +485,14 @@ class BaseSubAgent(ABC):
 
                 ctx.extract_from_tool_result(tool_name, integration, tool_args, content)
 
+                # Extract critical signals
+                for signal in self._extract_critical_signals(tool_name, content):
+                    ctx.add_critical_signal(signal)
+
+                # Update investigation plan
+                if ctx.investigation_plan:
+                    ctx.investigation_plan.mark_check_by_tool(tool_name, self.agent_id)
+
             except Exception as e:
                 execution_time = int((time.time() - start_time) * 1000)
                 input_items.append({
@@ -327,6 +505,254 @@ class BaseSubAgent(ABC):
                     "input": tool_args, "status": "error", "error": str(e),
                     "executionTimeMs": execution_time, "agentId": self.agent_id,
                 })
+
+    # ── Tool interception ──────────────────────────────────────
+
+    def _intercept_tool_args(self, tool_name: str, tool_args: dict[str, Any], integration: str | None = None) -> dict[str, Any]:
+        """Intercept and fix tool arguments before execution.
+
+        - For NRQL queries: fix timezone offsets, bare apdex(), wrong time windows.
+        - For Sentry tools: auto-inject time window filters.
+        - For all tools: validate timestamp arguments against the investigation window.
+        """
+        ctx = self.config.investigation_context
+        tw_start = ctx.time_window.get("start")
+        tw_end = ctx.time_window.get("end")
+
+        if not tw_start or not tw_end:
+            return tool_args
+
+        tool_lower = tool_name.lower()
+        integration_lower = (integration or "").lower()
+        is_sentry = "sentry" in integration_lower or "sentry" in tool_lower
+        is_nrql = "nrql" in tool_lower or "nr_run_nrql" in tool_lower
+
+        # NRQL query interception — fix common errors
+        if is_nrql and "nrql" in tool_args:
+            tool_args = {**tool_args, "nrql": self._fix_nrql_query(tool_args["nrql"], tw_start, tw_end)}
+
+        # Sentry time-window injection
+        if is_sentry and ("search" in tool_lower or "list_issue" in tool_lower or "list_issues" in tool_lower):
+            query = tool_args.get("query", "")
+            if "firstSeen" not in query and "lastSeen" not in query:
+                utc_start = tw_start.astimezone(timezone.utc) if tw_start.tzinfo else tw_start
+                utc_end = tw_end.astimezone(timezone.utc) if tw_end.tzinfo else tw_end
+                time_filter = f" firstSeen:>{utc_start.strftime('%Y-%m-%dT%H:%M:%S')} lastSeen:<{utc_end.strftime('%Y-%m-%dT%H:%M:%S')}"
+                tool_args = {**tool_args, "query": (query + time_filter).strip()}
+                logger.info("Injected time window into Sentry query: %s", tool_args["query"])
+
+        # Timestamp validation
+        self._validate_timestamps(tool_args, tw_start, tw_end)
+
+        return tool_args
+
+    def _fix_nrql_query(self, nrql: str, tw_start: datetime, tw_end: datetime) -> str:
+        """Fix common NRQL syntax issues before execution."""
+        original = nrql
+
+        # Normalize timestamps to UTC
+        utc_start = tw_start.astimezone(timezone.utc) if tw_start.tzinfo else tw_start.replace(tzinfo=timezone.utc)
+        utc_end = tw_end.astimezone(timezone.utc) if tw_end.tzinfo else tw_end.replace(tzinfo=timezone.utc)
+
+        # Fix 1: Replace timezone-offset timestamps with single-quoted UTC
+        # Pattern: SINCE 2026-02-20T00:48:21+05:30  or  SINCE 2026-02-20 00:48:21+05:30
+        tz_offset_pattern = r"(SINCE|UNTIL)\s+'?(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})[+-]\d{2}:\d{2}'?"
+        for match in re.finditer(tz_offset_pattern, nrql, re.IGNORECASE):
+            keyword = match.group(1)
+            ts_str = match.group(2)
+            try:
+                # Parse the original timestamp with offset to get the actual moment
+                full_match_str = match.group(0)
+                # Extract just the offset part from the original
+                offset_match = re.search(r'([+-]\d{2}:\d{2})', full_match_str)
+                if offset_match:
+                    full_ts = ts_str.replace("T", " ") + offset_match.group(1)
+                    parsed = datetime.fromisoformat(full_ts)
+                    utc_ts = parsed.astimezone(timezone.utc)
+                    nrql = nrql.replace(match.group(0), f"{keyword} '{utc_ts.strftime('%Y-%m-%d %H:%M:%S')}'")
+            except (ValueError, TypeError):
+                pass
+
+        # Fix 2: Replace bare apdex() or apdex(score:X) with apdex(duration, t: 0.5)
+        nrql = re.sub(r'apdex\(\)', 'apdex(duration, t: 0.5)', nrql)
+        nrql = re.sub(r'apdex\(score\s*:\s*[\d.]+\)', 'apdex(duration, t: 0.5)', nrql)
+
+        # Fix 3: Detect "SINCE X hours ago" when X is too small for the actual incident window
+        now = datetime.now(timezone.utc)
+        hours_since_incident_start = (now - utc_start).total_seconds() / 3600
+
+        if hours_since_incident_start > 4:  # Incident is more than 4 hours old
+            relative_match = re.search(r"SINCE\s+(\d+)\s+hours?\s+ago", nrql, re.IGNORECASE)
+            if relative_match:
+                requested_hours = int(relative_match.group(1))
+                # If the model is querying a recent window that doesn't overlap with the incident
+                if requested_hours < hours_since_incident_start - 1:
+                    # Check if there's also an UNTIL clause
+                    until_match = re.search(r"UNTIL\s+(\d+)\s+hours?\s+ago", nrql, re.IGNORECASE)
+                    if until_match:
+                        until_hours = int(until_match.group(1))
+                        # If the UNTIL is also recent (doesn't reach the incident), fix both
+                        if until_hours < int(hours_since_incident_start) - 2:
+                            padded_start_hours = int(hours_since_incident_start) + 1
+                            end_hours = max(0, int((now - utc_end).total_seconds() / 3600))
+                            nrql = re.sub(
+                                r"SINCE\s+\d+\s+hours?\s+ago\s+UNTIL\s+\d+\s+hours?\s+ago",
+                                f"SINCE {padded_start_hours} hours ago UNTIL {end_hours} hours ago",
+                                nrql,
+                                flags=re.IGNORECASE,
+                            )
+                    else:
+                        # No UNTIL clause — replace SINCE with the full incident window
+                        padded_start_hours = int(hours_since_incident_start) + 1
+                        end_hours = max(0, int((now - utc_end).total_seconds() / 3600))
+                        nrql = re.sub(
+                            r"SINCE\s+\d+\s+hours?\s+ago",
+                            f"SINCE {padded_start_hours} hours ago UNTIL {end_hours} hours ago",
+                            nrql,
+                            flags=re.IGNORECASE,
+                        )
+
+        # Fix 4: Unquoted absolute timestamps (SINCE 2024-01-15 14:00:00 without quotes)
+        nrql = re.sub(
+            r"(SINCE|UNTIL)\s+(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})(?!')",
+            r"\1 '\2'",
+            nrql,
+            flags=re.IGNORECASE,
+        )
+
+        if nrql != original:
+            logger.info("NRQL auto-corrected:\n  original: %s\n  fixed:    %s", original, nrql)
+
+        return nrql
+
+    def _validate_timestamps(self, tool_args: dict[str, Any], tw_start: datetime, tw_end: datetime) -> None:
+        """Validate and auto-correct timestamp arguments that are outside the investigation window."""
+        timestamp_keys = ["start_time", "end_time", "since", "from", "to", "startTime", "endTime", "start-time", "end-time"]
+
+        for key in timestamp_keys:
+            val = tool_args.get(key)
+            if not val or not isinstance(val, str):
+                continue
+
+            parsed_ts = self._try_parse_timestamp(val)
+            if not parsed_ts:
+                continue
+
+            # If timestamp is >24h outside the window, auto-correct
+            window_start_padded = tw_start - timedelta(hours=24)
+            window_end_padded = tw_end + timedelta(hours=24)
+
+            if parsed_ts < window_start_padded or parsed_ts > window_end_padded:
+                if "start" in key.lower() or key in ("since", "from"):
+                    corrected = tw_start - timedelta(minutes=30)
+                else:
+                    corrected = tw_end
+
+                logger.warning(
+                    "Timestamp %s=%s is outside investigation window [%s, %s]. Auto-correcting to %s.",
+                    key, val, tw_start.isoformat(), tw_end.isoformat(), corrected.isoformat(),
+                )
+                tool_args[key] = corrected.isoformat()
+
+    @staticmethod
+    def _try_parse_timestamp(val: str) -> datetime | None:
+        """Try to parse various timestamp formats."""
+        for fmt in [
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d",
+        ]:
+            try:
+                ts = datetime.strptime(val, fmt)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                return ts
+            except ValueError:
+                continue
+        # Try epoch milliseconds
+        try:
+            epoch_ms = int(val)
+            if epoch_ms > 1_000_000_000_000:  # epoch ms
+                return datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc)
+            elif epoch_ms > 1_000_000_000:  # epoch seconds
+                return datetime.fromtimestamp(epoch_ms, tz=timezone.utc)
+        except (ValueError, OverflowError, OSError):
+            pass
+        return None
+
+    def _post_process_tool_result(self, tool_name: str, content: str, integration: str | None = None) -> str:
+        """Post-process tool results. For Sentry: filter by time window and cap results."""
+        tool_lower = tool_name.lower()
+        integration_lower = (integration or "").lower()
+        if "sentry" not in integration_lower and "sentry" not in tool_lower:
+            return content
+
+        ctx = self.config.investigation_context
+        tw_start = ctx.time_window.get("start")
+        tw_end = ctx.time_window.get("end")
+        if not tw_start or not tw_end:
+            return content
+
+        # Widen the filter window by ±2 hours
+        filter_start = tw_start - timedelta(hours=2)
+        filter_end = tw_end + timedelta(hours=2)
+
+        try:
+            data = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return content
+
+        # Handle MCP-style nested content
+        if isinstance(data, dict) and isinstance(data.get("content"), list):
+            for block in data["content"]:
+                if isinstance(block, dict) and block.get("type") == "text" and block.get("text"):
+                    try:
+                        inner = json.loads(block["text"])
+                        if isinstance(inner, list):
+                            filtered = self._filter_sentry_issues(inner, filter_start, filter_end)
+                            block["text"] = json.dumps(filtered[:25])
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+            return json.dumps(data)
+
+        if isinstance(data, list):
+            filtered = self._filter_sentry_issues(data, filter_start, filter_end)
+            return json.dumps(filtered[:25])
+
+        return content
+
+    @staticmethod
+    def _filter_sentry_issues(issues: list[dict], start: datetime, end: datetime) -> list[dict]:
+        """Filter Sentry issues to those with lastSeen within the given window."""
+        filtered = []
+        for issue in issues:
+            last_seen_str = issue.get("lastSeen")
+            if not last_seen_str:
+                filtered.append(issue)  # Keep if we can't determine time
+                continue
+            try:
+                last_seen = datetime.fromisoformat(last_seen_str.replace("Z", "+00:00"))
+                if last_seen >= start:
+                    filtered.append(issue)
+            except (ValueError, TypeError):
+                filtered.append(issue)
+        return filtered
+
+    def _extract_critical_signals(self, tool_name: str, content: str) -> list[dict[str, Any]]:
+        """Scan tool output for critical patterns and return detected signals."""
+        signals: list[dict[str, Any]] = []
+        for pattern, category in CRITICAL_PATTERNS.items():
+            matches = re.findall(pattern, content[:10_000])  # Only scan first 10K chars
+            if matches:
+                signals.append({
+                    "category": category,
+                    "match": matches[0] if isinstance(matches[0], str) else str(matches[0]),
+                    "source_tool": tool_name,
+                    "agent_id": self.agent_id,
+                })
+        return signals
 
     def _emit_tool_update(
         self,

--- a/agent_service/agent/sub_agents/base.py
+++ b/agent_service/agent/sub_agents/base.py
@@ -24,6 +24,14 @@ SubAgentType = Literal["apm", "error_monitoring", "infrastructure", "alerting"]
 MAX_SUB_AGENT_ITERATIONS = 5
 MAX_TOOL_RESULT_CHARS = 30_000
 
+# Valid GroupBy Groups for Performance Insights get-resource-metrics
+PI_VALID_GROUPBY_GROUPS = {
+    "db.sql", "db.sql_tokenized", "db.host", "db.application",
+    "db.session_type", "db.user",
+}
+# These are valid as Metric names, NOT as GroupBy Groups
+PI_METRIC_ONLY_GROUPS = {"db.wait_event", "db.wait_state"}
+
 # Patterns for secrets that should be redacted from tool output
 _SECRET_PATTERNS = [
     # API keys and tokens with common prefixes
@@ -495,10 +503,18 @@ class BaseSubAgent(ABC):
 
             except Exception as e:
                 execution_time = int((time.time() - start_time) * 1000)
+                error_msg = f"TOOL ERROR — {tool_name} failed: {e}\n\nRetry with different parameters, or use an alternative tool."
+                # Add PI-specific hint for GroupBy errors
+                if ("resource_metrics" in tool_name.lower() or "get-resource-metrics" in tool_name.lower()) and "GroupBy" in str(e):
+                    error_msg += (
+                        "\n\nHINT: Valid GroupBy Groups for Performance Insights are: "
+                        "db.sql, db.sql_tokenized, db.host, db.application, db.session_type, db.user. "
+                        "db.wait_event and db.wait_state are Metrics, NOT GroupBy Groups."
+                    )
                 input_items.append({
                     "type": "function_call_output",
                     "call_id": fc["call_id"],
-                    "output": f"TOOL ERROR — {tool_name} failed: {e}\n\nRetry with different parameters, or use an alternative tool.",
+                    "output": error_msg,
                 })
                 self._emit_tool_update(all_tool_uses, on_tool_use, {
                     "id": fc["call_id"], "name": tool_name, "integration": integration,
@@ -508,13 +524,55 @@ class BaseSubAgent(ABC):
 
     # ── Tool interception ──────────────────────────────────────
 
+    def _intercept_pi_args(self, tool_name: str, tool_args: dict[str, Any]) -> dict[str, Any]:
+        """Intercept Performance Insights tool args to fix invalid GroupBy Groups."""
+        tool_lower = tool_name.lower()
+        if "resource_metrics" not in tool_lower and "get-resource-metrics" not in tool_lower:
+            return tool_args
+
+        metric_queries = tool_args.get("MetricQueries")
+        if not isinstance(metric_queries, list):
+            return tool_args
+
+        modified = False
+        for mq in metric_queries:
+            group_by = mq.get("GroupBy")
+            if not isinstance(group_by, dict):
+                continue
+            group = group_by.get("Group", "")
+            if group in PI_METRIC_ONLY_GROUPS:
+                logger.warning(
+                    "PI auto-correct: '%s' is a Metric, not a valid GroupBy Group. "
+                    "Replacing with 'db.sql_tokenized'.",
+                    group,
+                )
+                group_by["Group"] = "db.sql_tokenized"
+                modified = True
+            elif group and group not in PI_VALID_GROUPBY_GROUPS:
+                logger.warning(
+                    "PI auto-correct: unknown GroupBy Group '%s'. "
+                    "Replacing with 'db.sql_tokenized'. Valid groups: %s",
+                    group, ", ".join(sorted(PI_VALID_GROUPBY_GROUPS)),
+                )
+                group_by["Group"] = "db.sql_tokenized"
+                modified = True
+
+        if modified:
+            tool_args = {**tool_args, "MetricQueries": metric_queries}
+
+        return tool_args
+
     def _intercept_tool_args(self, tool_name: str, tool_args: dict[str, Any], integration: str | None = None) -> dict[str, Any]:
         """Intercept and fix tool arguments before execution.
 
+        - For PI tools: fix invalid GroupBy Groups.
         - For NRQL queries: fix timezone offsets, bare apdex(), wrong time windows.
         - For Sentry tools: auto-inject time window filters.
         - For all tools: validate timestamp arguments against the investigation window.
         """
+        # PI GroupBy validation (always, regardless of time window)
+        tool_args = self._intercept_pi_args(tool_name, tool_args)
+
         ctx = self.config.investigation_context
         tw_start = ctx.time_window.get("start")
         tw_end = ctx.time_window.get("end")
@@ -683,9 +741,18 @@ class BaseSubAgent(ABC):
         return None
 
     def _post_process_tool_result(self, tool_name: str, content: str, integration: str | None = None) -> str:
-        """Post-process tool results. For Sentry: filter by time window and cap results."""
+        """Post-process tool results to reduce token waste and improve quality."""
         tool_lower = tool_name.lower()
         integration_lower = (integration or "").lower()
+
+        # Compact all-zero NRQL TIMESERIES results
+        if "nrql" in tool_lower or "nr_run_nrql" in tool_lower:
+            content = self._compact_empty_timeseries(content)
+
+        # Summarize large CloudWatch log event outputs
+        if "filter_log_events" in tool_lower or "filter-log-events" in tool_lower:
+            content = self._summarize_log_events(content)
+
         if "sentry" not in integration_lower and "sentry" not in tool_lower:
             return content
 
@@ -739,6 +806,136 @@ class BaseSubAgent(ABC):
             except (ValueError, TypeError):
                 filtered.append(issue)
         return filtered
+
+    @staticmethod
+    def _compact_empty_timeseries(content: str) -> str:
+        """Replace all-zero NRQL TIMESERIES with a compact summary to save tokens."""
+        try:
+            data = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return content
+
+        if not isinstance(data, dict):
+            return content
+
+        results = data.get("results")
+        if not isinstance(results, list) or len(results) < 3:
+            return content
+
+        # Check if this is a TIMESERIES response (has beginTimeSeconds)
+        if not all(isinstance(r, dict) and "beginTimeSeconds" in r for r in results[:3]):
+            return content
+
+        # Check if ALL data values are zero/null
+        all_zero = True
+        for r in results:
+            for k, v in r.items():
+                if k in ("beginTimeSeconds", "endTimeSeconds", "inspectedCount"):
+                    continue
+                if isinstance(v, (int, float)) and v != 0:
+                    all_zero = False
+                    break
+                if isinstance(v, dict):
+                    if any(isinstance(sv, (int, float)) and sv != 0 for sv in v.values()):
+                        all_zero = False
+                        break
+            if not all_zero:
+                break
+
+        if all_zero:
+            # Replace with compact summary
+            n_buckets = len(results)
+            first_ts = results[0].get("beginTimeSeconds", 0)
+            last_ts = results[-1].get("endTimeSeconds", 0)
+            metric_keys = [k for k in results[0].keys() if k not in ("beginTimeSeconds", "endTimeSeconds", "inspectedCount")]
+            nrql = data.get("nrql", "")
+
+            summary = {
+                "nrql": nrql,
+                "summary": f"TIMESERIES returned 0 across all {n_buckets} time buckets for metrics: {', '.join(metric_keys)}",
+                "timeRange": {"beginTimeSeconds": first_ts, "endTimeSeconds": last_ts},
+                "totalBuckets": n_buckets,
+                "allZero": True,
+            }
+            logger.info("Compacted all-zero TIMESERIES: %d buckets → summary", n_buckets)
+            return json.dumps(summary)
+
+        return content
+
+    @staticmethod
+    def _summarize_log_events(content: str) -> str:
+        """Summarize large CloudWatch log event results into counts + samples."""
+        try:
+            data = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return content
+
+        if not isinstance(data, dict):
+            return content
+
+        events = data.get("events")
+        if not isinstance(events, list) or len(events) < 30:
+            return content  # Only summarize when there are many events
+
+        # Count events by message pattern (strip timestamps and connection IDs)
+        pattern_counts: dict[str, int] = {}
+        timestamps: list[int] = []
+
+        for event in events:
+            ts = event.get("timestamp")
+            if ts:
+                timestamps.append(ts)
+
+            msg = event.get("message", "")
+            # Normalize: strip leading timestamp, IP, user, PID
+            normalized = re.sub(
+                r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC:[\d.:()]+:\w+@\w+:\[\d+\]:',
+                '',
+                msg,
+            ).strip()
+            # Further normalize by removing unique identifiers
+            normalized = re.sub(r'\[\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\]', '[REQ_ID]', normalized)
+
+            if not normalized:
+                normalized = msg[:100]
+
+            # Group by first 80 chars of the normalized pattern
+            key = normalized[:80]
+            pattern_counts[key] = pattern_counts.get(key, 0) + 1
+
+        # Build summary
+        total = len(events)
+        time_range = ""
+        if timestamps:
+            min_ts = min(timestamps)
+            max_ts = max(timestamps)
+            min_dt = datetime.fromtimestamp(min_ts / 1000, tz=timezone.utc) if min_ts > 1_000_000_000_000 else datetime.fromtimestamp(min_ts, tz=timezone.utc)
+            max_dt = datetime.fromtimestamp(max_ts / 1000, tz=timezone.utc) if max_ts > 1_000_000_000_000 else datetime.fromtimestamp(max_ts, tz=timezone.utc)
+            time_range = f"{min_dt.strftime('%Y-%m-%d %H:%M:%S')} UTC to {max_dt.strftime('%Y-%m-%d %H:%M:%S')} UTC"
+
+        # Top patterns sorted by count
+        sorted_patterns = sorted(pattern_counts.items(), key=lambda x: -x[1])[:10]
+
+        summary_lines = [
+            f"**Log Events Summary** ({total} events{f', {time_range}' if time_range else ''})",
+            "",
+            "**Event patterns (top by frequency):**",
+        ]
+        for pattern, count in sorted_patterns:
+            summary_lines.append(f"  - [{count}x] {pattern}")
+
+        # Include 3 sample raw messages
+        summary_lines.append("")
+        summary_lines.append("**Sample messages:**")
+        for event in events[:3]:
+            summary_lines.append(f"  - {event.get('message', '')[:200]}")
+
+        has_next = data.get("nextToken") or data.get("nextForwardToken")
+        if has_next:
+            summary_lines.append(f"\n(Results were paginated — {total} events shown, more available)")
+
+        logger.info("Summarized %d log events into compact summary", total)
+        return "\n".join(summary_lines)
 
     def _extract_critical_signals(self, tool_name: str, content: str) -> list[dict[str, Any]]:
         """Scan tool output for critical patterns and return detected signals."""

--- a/agent_service/agent/sub_agents/error_monitoring.py
+++ b/agent_service/agent/sub_agents/error_monitoring.py
@@ -11,6 +11,7 @@ from ..prompts import GUIDANCE_SENTRY
 class ErrorMonitoringAgent(BaseSubAgent):
     agent_id = "error_monitoring"  # type: ignore[assignment]
     agent_type = "Error Monitoring Agent"
+    shared_integrations = ["github"]
 
     def __init__(self, config: SubAgentConfig) -> None:
         super().__init__(config)

--- a/agent_service/agent/sub_agents/error_monitoring.py
+++ b/agent_service/agent/sub_agents/error_monitoring.py
@@ -20,14 +20,30 @@ class ErrorMonitoringAgent(BaseSubAgent):
         # Error monitoring agent must always search for issues
         return ["sentry"]
 
+    def get_excluded_tool_patterns(self, task: str) -> list[str]:
+        excluded = []
+        ctx = self.config.investigation_context
+        has_sentry_projects = any(r.type == "sentry_project" for r in ctx.resources)
+        if has_sentry_projects:
+            excluded.extend(["find_organization", "find_project", "list_project"])
+        return excluded
+
     def get_own_tools(self) -> list[dict[str, Any]]:
         return self.get_mcp_tools("sentry")
 
     def get_system_prompt(self) -> str:
+        ctx = self.config.investigation_context
+        has_sentry_projects = any(r.type == "sentry_project" for r in ctx.resources)
+        discovery_rule = (
+            "1. Use the Sentry project slugs from the investigation context — do NOT call find_organization or find_project."
+            if has_sentry_projects
+            else "1. Discover project slugs first — they may differ from service names in other platforms."
+        )
+
         return f"""You are an error monitoring investigation agent specializing in Sentry data. Your job is to query Sentry for error tracking, stack traces, issue frequency, and affected users — always scoped to the investigation time window.
 
 # Core Rules
-1. Discover project slugs first — they may differ from service names in other platforms.
+{discovery_rule}
 2. **Always filter by time window.** Compare each issue's `firstSeen`/`lastSeen` against the investigation time window. Skip issues whose `lastSeen` is before the window.
 3. **Never report total/lifetime event counts.** They are misleading. Instead classify each issue as NEW (firstSeen within window) or RECURRING (active during window).
 4. Always retrieve full stack traces for the most relevant errors within the time window.

--- a/agent_service/agent/sub_agents/error_monitoring.py
+++ b/agent_service/agent/sub_agents/error_monitoring.py
@@ -16,28 +16,39 @@ class ErrorMonitoringAgent(BaseSubAgent):
     def __init__(self, config: SubAgentConfig) -> None:
         super().__init__(config)
 
+    def get_required_tool_patterns(self, task: str) -> list[str]:
+        # Error monitoring agent must always search for issues
+        return ["sentry"]
+
     def get_own_tools(self) -> list[dict[str, Any]]:
         return self.get_mcp_tools("sentry")
 
     def get_system_prompt(self) -> str:
-        return f"""You are an error monitoring investigation agent specializing in Sentry data. Your job is to query Sentry for error tracking, stack traces, issue frequency, and affected users.
+        return f"""You are an error monitoring investigation agent specializing in Sentry data. Your job is to query Sentry for error tracking, stack traces, issue frequency, and affected users — always scoped to the investigation time window.
 
 # Core Rules
 1. Discover project slugs first — they may differ from service names in other platforms.
-2. Get the top issues by frequency and affected user count.
-3. Always retrieve full stack traces for the most relevant errors.
-4. Check firstSeen/lastSeen to determine if errors are new (from a recent deploy).
-5. Report specific error messages, file:line references, and frequencies.
+2. **Always filter by time window.** Compare each issue's `firstSeen`/`lastSeen` against the investigation time window. Skip issues whose `lastSeen` is before the window.
+3. **Never report total/lifetime event counts.** They are misleading. Instead classify each issue as NEW (firstSeen within window) or RECURRING (active during window).
+4. Always retrieve full stack traces for the most relevant errors within the time window.
+5. Report specific error messages, file:line references, and affected user counts.
 6. If a tool call fails, fix parameters and retry immediately.
 
+# Investigation Depth
+- Get the list of issues, then FILTER by time window before analyzing further.
+- For each relevant issue, get the full event details including stack traces.
+- Look for error clusters: multiple different errors that started around the same time point to a shared root cause (bad deploy, DB failure, config change).
+- Check if errors correlate with specific releases or deployments.
+- Identify the FIRST error that appeared in the window — this is often the root cause, with subsequent errors being cascading failures.
+
 # Focus Areas
-- Top errors by frequency and user impact
-- Full stack traces with file:line references
-- Error trends (new vs recurring)
+- Errors active during the investigation time window (not all-time)
+- Full stack traces with file:line references for top issues
+- Error timeline: which errors appeared first, which followed
+- Error clusters sharing a common trigger
 - Affected user counts and sessions
-- Error grouping and fingerprints
 - Release/deployment correlation
 
 {GUIDANCE_SENTRY}
 
-Produce a concise findings summary with specific error details, stack traces, and frequencies when done."""
+Produce a concise findings summary with: (1) errors filtered to the time window, (2) timeline of when each error first appeared, (3) stack traces for the top issues, (4) likely root cause connecting the error cluster."""

--- a/agent_service/agent/sub_agents/infrastructure.py
+++ b/agent_service/agent/sub_agents/infrastructure.py
@@ -15,6 +15,45 @@ class InfrastructureAgent(BaseSubAgent):
     def __init__(self, config: SubAgentConfig) -> None:
         super().__init__(config)
 
+    def get_required_tool_patterns(self, task: str) -> list[str]:
+        task_lower = task.lower()
+        patterns = []
+        if any(kw in task_lower for kw in ["rds", "database", "db", "aurora", "postgres", "mysql"]):
+            patterns.extend(["cloudwatch", "rds"])
+            # Require PI when investigating database incidents and PI resources exist
+            ctx = self.config.investigation_context
+            if any(r.type == "rds" and r.attrs.get("piEnabled") == "True" for r in ctx.resources):
+                patterns.append("pi")
+        if any(kw in task_lower for kw in ["ec2", "instance", "server"]):
+            patterns.append("cloudwatch")
+        if any(kw in task_lower for kw in ["lambda", "function"]):
+            patterns.append("cloudwatch")
+        if any(kw in task_lower for kw in ["ecs", "fargate", "container"]):
+            patterns.append("cloudwatch")
+        if any(kw in task_lower for kw in ["log", "error pattern"]):
+            patterns.append("logs")
+        return patterns
+
+    def get_excluded_tool_patterns(self, task: str) -> list[str]:
+        task_lower = task.lower()
+        excluded = []
+        is_db = any(kw in task_lower for kw in ["rds", "database", "db", "aurora", "postgres", "mysql"])
+        is_lambda = any(kw in task_lower for kw in ["lambda", "function"])
+        is_ec2 = any(kw in task_lower for kw in ["ec2", "instance", "server"])
+        is_ecs = any(kw in task_lower for kw in ["ecs", "fargate", "container"])
+
+        # Exclude Lambda tools when investigating non-Lambda resources
+        if not is_lambda and (is_db or is_ec2 or is_ecs):
+            excluded.extend(["list_functions", "get_function"])
+        # Exclude ECS tools when investigating non-ECS resources
+        if not is_ecs and (is_db or is_ec2 or is_lambda):
+            excluded.extend(["list_clusters", "describe_clusters", "list_services", "describe_services", "list_tasks", "describe_tasks"])
+        # Exclude EC2 tools when investigating non-EC2 resources
+        if not is_ec2 and (is_db or is_lambda or is_ecs):
+            excluded.append("describe_instances")
+
+        return excluded
+
     def get_own_tools(self) -> list[dict[str, Any]]:
         # Use MCP AWS tools (call_aws, suggest_aws_commands) when available,
         # plus custom boto3 tools from the registry
@@ -23,7 +62,40 @@ class InfrastructureAgent(BaseSubAgent):
         return [*mcp_tools, *registry_tools]
 
     def get_system_prompt(self) -> str:
-        return f"""You are an infrastructure investigation agent specializing in AWS data. You have access to AWS tools that let you query CloudWatch metrics, EC2 instances, Lambda functions, RDS databases, and CloudWatch Logs.
+        # Check if any discovered RDS resources have Performance Insights enabled
+        ctx = self.config.investigation_context
+        pi_resources = []
+        for r in ctx.resources:
+            if r.type == "rds" and r.attrs.get("piEnabled") == "True":
+                pi_resources.append(r)
+
+        pi_section = ""
+        if pi_resources:
+            pi_ids = ", ".join(f"`{r.id}`" for r in pi_resources if r.id)
+            pi_section = f"""
+
+# Performance Insights (MANDATORY — PI is enabled on: {', '.join(r.name for r in pi_resources)})
+
+You MUST call Performance Insights for these RDS instances. This is the HIGHEST PRIORITY investigation step for database incidents because it reveals WHICH specific SQL queries caused the CPU spike.
+
+Use `aws_get_resource_metrics` with:
+- **ServiceType**: "RDS"
+- **Identifier**: The DbiResourceId (e.g. {pi_ids}) — NOT the instance name
+- **MetricQueries**: Use `db.load` metric with `GroupBy` dimensions:
+  - `db.sql` — Top SQL statements by load
+  - `db.wait_event` — Top wait events (CPU, IO, Lock, etc.)
+- **StartTime** / **EndTime**: Use the investigation time window (ISO 8601)
+- **PeriodInSeconds**: 60 for detailed view
+
+Also call `aws_describe_dimension_keys` with:
+- **ServiceType**: "RDS"
+- **Identifier**: The DbiResourceId
+- **Metric**: `db.load`
+- **GroupBy**: `db.sql` to get the top SQL queries ranked by DB load
+
+This data tells you exactly which queries consumed the most CPU — this is the root cause evidence."""
+
+        return f"""You are an infrastructure investigation agent specializing in AWS data. You have access to AWS tools that let you query CloudWatch metrics, EC2 instances, Lambda functions, RDS databases, CloudWatch Logs, and Performance Insights.
 
 # Rules
 1. Always include region context in your queries.
@@ -31,12 +103,31 @@ class InfrastructureAgent(BaseSubAgent):
 3. Empty results may mean wrong region — try alternatives.
 4. Report specific metric values, not vague descriptions.
 5. Use resource names and IDs from the investigation context when available — do not re-discover.
+6. **Always compare incident-window metrics against baseline** (the period before the incident) to show what changed.
+{pi_section}
+
+# Investigation Sequence
+For any investigation, follow this sequence:
+1. **CloudWatch Alarms** — Check alarm states for affected resources.
+2. **Compute health** — EC2/ECS/Lambda status and key metrics.
+3. **Database investigation** (MANDATORY when any RDS/database is in scope):
+   a. CloudWatch metrics: CPUUtilization, DatabaseConnections, FreeableMemory, ReadLatency, WriteLatency, DiskQueueDepth
+   b. **Performance Insights** (MANDATORY when PI is enabled): Top SQL queries and wait events during the incident window. This is the MOST IMPORTANT step for identifying root cause.
+   c. Compare DB metrics during incident vs. baseline period before
+4. **CloudWatch Logs** — Search application and infrastructure logs for error patterns, timeouts, and connection issues during the incident window.
+   - For PostgreSQL databases, search with filter pattern `"duration"` (PostgreSQL logs slow queries as `duration: X ms`). Do NOT search for `"slow"` — PostgreSQL does not use that word.
+   - Also search for `"ERROR"`, `"FATAL"`, `"canceling statement"`, `"connection"`.
+5. **Network/connectivity** — Check for timeout patterns, connection refused errors, and load balancer metrics if applicable.
 
 # Focus Areas
-- CloudWatch alarms, metrics, and logs
-- EC2, Lambda, ECS health
-- RDS performance, connections, Performance Insights, slow query logs
+- CloudWatch alarms and their state changes
+- EC2, Lambda, ECS health and resource utilization
+- **RDS/Database**: CPU, connections, latency, slow queries, Performance Insights wait events, connection pool exhaustion
+- **Performance Insights**: Top SQL queries by DB load, wait event breakdown (CPU vs IO vs Lock) — this identifies the root cause
+- **CloudWatch Logs**: Error patterns, timeout patterns, unusual log entries scoped to the investigation time window
+- Load balancer metrics (5xx errors, latency, healthy host count)
+- Resource utilization trends (before vs during incident)
 
 {GUIDANCE_AWS}
 
-Produce a concise findings summary with specific metrics, alarm states, and resource health when done."""
+Produce a concise findings summary with: (1) alarm states and changes, (2) database health with specific metrics and comparisons, (3) **Performance Insights top SQL queries** (when available), (4) log patterns found during the incident window, (5) resource utilization before vs during the incident."""

--- a/agent_service/agent/sub_agents/infrastructure.py
+++ b/agent_service/agent/sub_agents/infrastructure.py
@@ -52,6 +52,12 @@ class InfrastructureAgent(BaseSubAgent):
         if not is_ec2 and (is_db or is_lambda or is_ecs):
             excluded.append("describe_instances")
 
+        # Skip RDS discovery when instances are already known from resource map
+        ctx = self.config.investigation_context
+        has_rds = any(r.type == "rds" for r in ctx.resources)
+        if has_rds:
+            excluded.append("describe_db_instances")
+
         return excluded
 
     def get_own_tools(self) -> list[dict[str, Any]]:
@@ -78,22 +84,35 @@ class InfrastructureAgent(BaseSubAgent):
 
 You MUST call Performance Insights for these RDS instances. This is the HIGHEST PRIORITY investigation step for database incidents because it reveals WHICH specific SQL queries caused the CPU spike.
 
-Use `aws_get_resource_metrics` with:
+**Step 1 — Top SQL by load:** Call `aws_describe_dimension_keys` with:
 - **ServiceType**: "RDS"
 - **Identifier**: The DbiResourceId (e.g. {pi_ids}) — NOT the instance name
-- **MetricQueries**: Use `db.load` metric with `GroupBy` dimensions:
-  - `db.sql` — Top SQL statements by load
-  - `db.wait_event` — Top wait events (CPU, IO, Lock, etc.)
+- **Metric**: `db.load`
+- **GroupBy**: {{"Group": "db.sql_tokenized", "Dimensions": ["db.sql_tokenized.statement"]}}
 - **StartTime** / **EndTime**: Use the investigation time window (ISO 8601)
-- **PeriodInSeconds**: 60 for detailed view
+- **PeriodInSeconds**: 60
 
-Also call `aws_describe_dimension_keys` with:
+**Step 2 — Load timeseries:** Call `aws_get_resource_metrics` with:
 - **ServiceType**: "RDS"
 - **Identifier**: The DbiResourceId
-- **Metric**: `db.load`
-- **GroupBy**: `db.sql` to get the top SQL queries ranked by DB load
+- **MetricQueries**: Use Metric `db.load` with GroupBy Group `db.sql_tokenized`
+- **StartTime** / **EndTime**: Same as Step 1
+- **PeriodInSeconds**: 60
+
+**Valid GroupBy Groups** (use ONLY these in GroupBy.Group):
+  `db.sql`, `db.sql_tokenized`, `db.host`, `db.application`, `db.session_type`, `db.user`
+
+**WARNING:** `db.wait_event` and `db.wait_state` are **Metrics**, NOT GroupBy Groups.
+  To analyze wait events, use them as the **Metric** field (e.g. Metric=`db.wait_event`), not in GroupBy.Group.
 
 This data tells you exactly which queries consumed the most CPU — this is the root cause evidence."""
+
+        has_rds = any(r.type == "rds" for r in ctx.resources)
+        discovery_rule = (
+            "5. RDS instances are already known from the investigation context — do NOT call describe_db_instances. Use the instance names and DbiResourceIds directly."
+            if has_rds
+            else "5. Use resource names and IDs from the investigation context when available — do not re-discover."
+        )
 
         return f"""You are an infrastructure investigation agent specializing in AWS data. You have access to AWS tools that let you query CloudWatch metrics, EC2 instances, Lambda functions, RDS databases, CloudWatch Logs, and Performance Insights.
 
@@ -102,7 +121,7 @@ This data tells you exactly which queries consumed the most CPU — this is the 
 2. If a command fails, read the error, fix parameters, retry.
 3. Empty results may mean wrong region — try alternatives.
 4. Report specific metric values, not vague descriptions.
-5. Use resource names and IDs from the investigation context when available — do not re-discover.
+{discovery_rule}
 6. **Always compare incident-window metrics against baseline** (the period before the incident) to show what changed.
 {pi_section}
 

--- a/frontend/components/ChatInterface.vue
+++ b/frontend/components/ChatInterface.vue
@@ -6,12 +6,23 @@
         <h1 class="text-sm font-medium truncate mr-4">
           {{ conversationTitle }}
         </h1>
-        <button
-          @click="newConversation"
-          class="shrink-0 px-4 py-2 border border-gray-300 dark:border-gray-700 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black transition-colors text-sm"
-        >
-          New Conversation
-        </button>
+        <div class="flex items-center gap-2">
+          <button
+            @click="copyDebug"
+            :disabled="messages.length === 0"
+            class="shrink-0 flex items-center gap-1.5 px-3 py-2 border border-gray-300 dark:border-gray-700 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black transition-colors text-sm disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ClipboardDocumentIcon v-if="!debugCopied" class="w-3.5 h-3.5" />
+            <ClipboardDocumentCheckIcon v-else class="w-3.5 h-3.5 text-green-600 dark:text-green-400" />
+            <span>{{ debugCopied ? 'Copied' : 'Copy Debug' }}</span>
+          </button>
+          <button
+            @click="newConversation"
+            class="shrink-0 px-4 py-2 border border-gray-300 dark:border-gray-700 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black transition-colors text-sm"
+          >
+            New Conversation
+          </button>
+        </div>
       </div>
     </div>
 
@@ -209,8 +220,10 @@
 import { ref, computed, onMounted, watch, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import { LockClosedIcon } from '@heroicons/vue/24/solid';
+import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline';
 import { useAgent } from '../composables/useAgent';
 import { useAgentStore } from '../stores/agent';
+import type { ToolUse, EvaluationResult } from '../types';
 import MessageList from './MessageList.vue';
 import WelcomeScreen from './WelcomeScreen.vue';
 import ToolUsageIndicator from './ToolUsageIndicator.vue';
@@ -331,6 +344,126 @@ const hasActiveThread = computed(() =>
 const conversationTitle = computed(() =>
   agentStore.currentConversation?.title || 'New Conversation'
 );
+
+// ── Debug copy ──────────────────────────────────────────────────
+const debugCopied = ref(false);
+
+function formatToolUse(tu: ToolUse): string {
+  const lines: string[] = [];
+  lines.push(`Tool: ${tu.name}`);
+  if (tu.integration) lines.push(`Integration: ${tu.integration}`);
+  if (tu.agentId) lines.push(`Agent: ${tu.agentId}`);
+  lines.push(`Status: ${tu.status}${tu.executionTimeMs != null ? ` (${tu.executionTimeMs}ms)` : ''}`);
+  if (tu.input && Object.keys(tu.input).length > 0) {
+    lines.push(`Input: ${JSON.stringify(tu.input, null, 2)}`);
+  }
+  if (tu.error) {
+    lines.push(`Error: ${tu.error}`);
+  }
+  if (tu.output != null) {
+    const outputStr = typeof tu.output === 'string' ? tu.output : JSON.stringify(tu.output, null, 2);
+    lines.push(`Output: ${outputStr}`);
+  }
+  return lines.join('\n');
+}
+
+function formatEvaluation(ev: { iteration: number; evaluation: EvaluationResult }): string {
+  const e = ev.evaluation;
+  const lines = [
+    `Iteration: ${ev.iteration}`,
+    `Status: ${e.status} | Confidence: ${e.confidence}%`,
+    `Summary: ${e.summary}`,
+  ];
+  if (e.nextSteps?.length > 0) {
+    lines.push('Next Steps:');
+    for (const step of e.nextSteps) {
+      lines.push(`  → ${step}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function buildDebugDump(): string {
+  const conv = agentStore.currentConversation;
+  if (!conv) return '';
+
+  const sections: string[] = [];
+  const divider = '─'.repeat(60);
+
+  // Header
+  sections.push([
+    `# Debug Dump: ${conv.title || 'Untitled Conversation'}`,
+    `Conversation ID: ${conv.id}`,
+    `Created: ${conv.createdAt}`,
+    `Messages: ${conv.messages.length}`,
+  ].join('\n'));
+
+  // Messages
+  for (const msg of conv.messages) {
+    const ts = new Date(msg.createdAt).toISOString();
+
+    if (msg.messageType === 'tool_use' && msg.toolUses) {
+      sections.push([
+        divider,
+        `## [TOOL] ${ts}`,
+        formatToolUse(msg.toolUses),
+      ].join('\n'));
+    } else if (msg.messageType === 'evaluation' && msg.reasoning) {
+      sections.push([
+        divider,
+        `## [EVALUATION] ${ts}`,
+        formatEvaluation(msg.reasoning),
+      ].join('\n'));
+    } else if (msg.messageType === 'note') {
+      const mentionStr = msg.mentions?.length
+        ? `\nMentions: ${msg.mentions.map(m => `@${m.name}`).join(', ')}`
+        : '';
+      sections.push([
+        divider,
+        `## [NOTE] ${ts}`,
+        msg.content,
+        mentionStr,
+      ].filter(Boolean).join('\n'));
+    } else if (msg.role === 'user') {
+      sections.push([
+        divider,
+        `## [USER] ${ts}`,
+        msg.content,
+      ].join('\n'));
+    } else if (msg.role === 'assistant') {
+      sections.push([
+        divider,
+        `## [ASSISTANT] ${ts}`,
+        msg.content,
+      ].join('\n'));
+    }
+  }
+
+  return sections.join('\n\n');
+}
+
+async function copyDebug() {
+  const dump = buildDebugDump();
+  if (!dump) return;
+
+  try {
+    await navigator.clipboard.writeText(dump);
+    debugCopied.value = true;
+    setTimeout(() => { debugCopied.value = false; }, 1500);
+  } catch {
+    // Fallback for non-secure contexts
+    const textarea = document.createElement('textarea');
+    textarea.value = dump;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+    debugCopied.value = true;
+    setTimeout(() => { debugCopied.value = false; }, 1500);
+  }
+}
 
 // ── Scroll tracking ──────────────────────────────────────────────
 const isNearBottom = ref(true);


### PR DESCRIPTION
- Auto-resolve resource scope from user messages — matches service names, PagerDuty URLs, and quoted strings against resource maps before the first dispatch, eliminating the _get_connected_resources tool call round-trip
- Optimize follow-up queries — adds directives to answer from existing context first, dispatch to at most one sub-agent, and skip resource re-discovery on follow-up messages
- Fix AWS Performance Insights usage — corrects PI tool guidance (describe-dimension-keys before get-resource-metrics), auto-corrects invalid GroupBy Groups (e.g. db.wait_event → db.sql_tokenized), and adds error hints for PI failures
- Skip redundant discovery tools — excludes nr_list_entities, find_organization/find_project, and describe_db_instances when resources are already known from the investigation context
- Reduce token waste — compacts all-zero NRQL TIMESERIES responses into summaries, and condenses large CloudWatch log outputs into pattern counts with samples
- Track Performance Insights findings — extracts top SQL queries and resource load metrics from PI tool results into the investigation context for use in reports