### PR TITLE
feat: Add Hetzner Cloud integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ All integrations are configured in **Settings** from the UI. Credentials are enc
 | **AWS** | Native (boto3) | CloudWatch, EC2, Lambda, RDS, ECS |
 | **GitHub** | MCP — `@modelcontextprotocol/server-github` (stdio) | Code search, file content, commits, blame |
 | **PagerDuty** | Native + MCP — `mcp.pagerduty.com` (streamable-http) | Incidents, services, escalation policies, on-call schedules |
+| **Hetzner Cloud** | Native (REST API v1) | Servers, load balancers, firewalls, networks, volumes, metrics |
 
 All integrations except OpenAI support multiple instances (e.g. multiple AWS accounts).
 

--- a/agent_service/agent/discovery.py
+++ b/agent_service/agent/discovery.py
@@ -392,6 +392,70 @@ async def _discover_sentry(settings: dict[str, Any]) -> list[dict[str, Any]]:
     return nodes
 
 
+# ── Hetzner ──────────────────────────────────────────────────────
+
+
+async def _discover_hetzner_instance(instance: dict[str, str]) -> list[dict[str, Any]]:
+    api_token = instance.get("api_token")
+    if not api_token:
+        return []
+
+    headers = {"Authorization": f"Bearer {api_token}"}
+    nodes: list[dict[str, Any]] = []
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.hetzner.cloud/v1/servers",
+                headers=headers,
+                timeout=30,
+            )
+            resp.raise_for_status()
+
+        servers = resp.json().get("servers", [])
+        for srv in servers:
+            public_net = srv.get("public_net", {})
+            ipv4 = public_net.get("ipv4", {}).get("ip", "") if isinstance(public_net.get("ipv4"), dict) else ""
+            location = srv.get("datacenter", {}).get("location", {})
+
+            nodes.append(_node(
+                name=srv["name"],
+                type="server",
+                source="hetzner",
+                external_id=str(srv.get("id", "")),
+                attrs={
+                    "status": srv.get("status", ""),
+                    "server_type": srv.get("server_type", {}).get("description", ""),
+                    "public_ipv4": ipv4,
+                    "datacenter": srv.get("datacenter", {}).get("name", ""),
+                    "location": location.get("city", ""),
+                },
+            ))
+
+        logger.info("Hetzner discovery: %d servers", len(nodes))
+    except Exception as exc:
+        logger.warning("Hetzner discovery failed: %s", exc)
+
+    return nodes
+
+
+async def _discover_hetzner(settings: dict[str, Any]) -> list[dict[str, Any]]:
+    instances = _get_instances(settings, "hetzner")
+    if not instances:
+        return []
+    results = await asyncio.gather(
+        *[_discover_hetzner_instance(inst) for inst in instances],
+        return_exceptions=True,
+    )
+    nodes: list[dict[str, Any]] = []
+    for result in results:
+        if isinstance(result, Exception):
+            logger.warning("Hetzner instance discovery failed: %s", result)
+        else:
+            nodes.extend(result)
+    return nodes
+
+
 # ── Edge inference ───────────────────────────────────────────────
 
 
@@ -526,6 +590,7 @@ async def discover_resources(
         _discover_aws(settings),
         _discover_pagerduty(settings),
         _discover_sentry(settings),
+        _discover_hetzner(settings),
     ]
 
     results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/agent_service/agent/integrations/hetzner/__init__.py
+++ b/agent_service/agent/integrations/hetzner/__init__.py
@@ -1,0 +1,339 @@
+"""Hetzner Cloud custom tools — direct REST API v1 tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from ..tool_registry import ToolDefinition, tool_registry
+
+HETZNER_BASE = "https://api.hetzner.cloud/v1"
+
+
+def get_hetzner_credentials(settings: dict[str, Any], instance: int = 0) -> dict[str, str]:
+    api_token = settings.get(f"hetzner.{instance}.api_token")
+    if not api_token:
+        raise ValueError("Hetzner API token not configured.")
+    return {"api_token": api_token}
+
+
+def _hetzner_headers(settings: dict[str, Any]) -> dict[str, str]:
+    creds = get_hetzner_credentials(settings)
+    return {
+        "Authorization": f"Bearer {creds['api_token']}",
+        "Content-Type": "application/json",
+    }
+
+
+# ── Servers ──────────────────────────────────────────────────────
+
+
+async def _hetzner_list_servers(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    params: dict[str, Any] = {"per_page": args.get("per_page", 50)}
+    if args.get("page"):
+        params["page"] = args["page"]
+    if args.get("status"):
+        params["status"] = args["status"]
+    if args.get("name"):
+        params["name"] = args["name"]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/servers", headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+
+    servers = resp.json().get("servers", [])
+    return {"title": f"Hetzner Servers ({len(servers)})", "output": json.dumps({"servers": servers}, indent=2)}
+
+
+async def _hetzner_get_server(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/servers/{args['server_id']}", headers=headers, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Server: {args['server_id']}", "output": json.dumps(resp.json().get("server", {}), indent=2)}
+
+
+async def _hetzner_get_server_metrics(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    params: dict[str, Any] = {
+        "type": args.get("type", "cpu,disk,network"),
+        "start": args["start"],
+        "end": args["end"],
+    }
+    if args.get("step"):
+        params["step"] = args["step"]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{HETZNER_BASE}/servers/{args['server_id']}/metrics",
+            headers=headers, params=params, timeout=30,
+        )
+        resp.raise_for_status()
+    return {"title": f"Server Metrics: {args['server_id']}", "output": json.dumps(resp.json().get("metrics", {}), indent=2)}
+
+
+# ── Load Balancers ───────────────────────────────────────────────
+
+
+async def _hetzner_list_load_balancers(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    params: dict[str, Any] = {"per_page": args.get("per_page", 50)}
+    if args.get("name"):
+        params["name"] = args["name"]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/load_balancers", headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+
+    lbs = resp.json().get("load_balancers", [])
+    return {"title": f"Hetzner Load Balancers ({len(lbs)})", "output": json.dumps({"load_balancers": lbs}, indent=2)}
+
+
+async def _hetzner_get_load_balancer(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/load_balancers/{args['load_balancer_id']}", headers=headers, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Load Balancer: {args['load_balancer_id']}", "output": json.dumps(resp.json().get("load_balancer", {}), indent=2)}
+
+
+async def _hetzner_get_load_balancer_metrics(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    params: dict[str, Any] = {
+        "type": args.get("type", "requests_per_second,bandwidth.in,bandwidth.out,connections_per_second"),
+        "start": args["start"],
+        "end": args["end"],
+    }
+    if args.get("step"):
+        params["step"] = args["step"]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{HETZNER_BASE}/load_balancers/{args['load_balancer_id']}/metrics",
+            headers=headers, params=params, timeout=30,
+        )
+        resp.raise_for_status()
+    return {"title": f"LB Metrics: {args['load_balancer_id']}", "output": json.dumps(resp.json().get("metrics", {}), indent=2)}
+
+
+# ── Firewalls ────────────────────────────────────────────────────
+
+
+async def _hetzner_list_firewalls(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/firewalls", headers=headers, timeout=30)
+        resp.raise_for_status()
+    firewalls = resp.json().get("firewalls", [])
+    return {"title": f"Hetzner Firewalls ({len(firewalls)})", "output": json.dumps({"firewalls": firewalls}, indent=2)}
+
+
+# ── Networks ─────────────────────────────────────────────────────
+
+
+async def _hetzner_list_networks(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/networks", headers=headers, timeout=30)
+        resp.raise_for_status()
+    networks = resp.json().get("networks", [])
+    return {"title": f"Hetzner Networks ({len(networks)})", "output": json.dumps({"networks": networks}, indent=2)}
+
+
+async def _hetzner_get_network(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/networks/{args['network_id']}", headers=headers, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Network: {args['network_id']}", "output": json.dumps(resp.json().get("network", {}), indent=2)}
+
+
+# ── Volumes ──────────────────────────────────────────────────────
+
+
+async def _hetzner_list_volumes(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    params: dict[str, Any] = {}
+    if args.get("status"):
+        params["status"] = args["status"]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/volumes", headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+    volumes = resp.json().get("volumes", [])
+    return {"title": f"Hetzner Volumes ({len(volumes)})", "output": json.dumps({"volumes": volumes}, indent=2)}
+
+
+# ── Floating IPs ─────────────────────────────────────────────────
+
+
+async def _hetzner_list_floating_ips(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/floating_ips", headers=headers, timeout=30)
+        resp.raise_for_status()
+    ips = resp.json().get("floating_ips", [])
+    return {"title": f"Hetzner Floating IPs ({len(ips)})", "output": json.dumps({"floating_ips": ips}, indent=2)}
+
+
+# ── SSH Keys ─────────────────────────────────────────────────────
+
+
+async def _hetzner_list_ssh_keys(args: dict, ctx: Any) -> dict:
+    headers = _hetzner_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{HETZNER_BASE}/ssh_keys", headers=headers, timeout=30)
+        resp.raise_for_status()
+    keys = resp.json().get("ssh_keys", [])
+    return {"title": f"SSH Keys ({len(keys)})", "output": json.dumps({"ssh_keys": keys}, indent=2)}
+
+
+# ── Tool Definitions ─────────────────────────────────────────────
+
+HETZNER_TOOLS = [
+    ToolDefinition(
+        name="hetzner_list_servers",
+        description="List all Hetzner Cloud servers with status, IPs, server type, datacenter, and labels.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "per_page": {"type": "number", "description": "Results per page (default 50)"},
+                "page": {"type": "number", "description": "Page number"},
+                "status": {"type": "string", "description": "Filter by status: running, initializing, starting, stopping, off, deleting, migrating, rebuilding, unknown"},
+                "name": {"type": "string", "description": "Filter by server name"},
+            },
+        },
+        execute=_hetzner_list_servers,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_get_server",
+        description="Get details of a specific Hetzner server by ID, including status, IPs, server type, datacenter, volumes, and labels.",
+        parameters={
+            "type": "object",
+            "properties": {"server_id": {"type": "string", "description": "Server ID"}},
+            "required": ["server_id"],
+        },
+        execute=_hetzner_get_server,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_get_server_metrics",
+        description="Get metrics (CPU, disk, network) for a Hetzner server. Requires server_id and ISO 8601 start/end timestamps.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "server_id": {"type": "string", "description": "Server ID"},
+                "type": {"type": "string", "description": "Comma-separated metric types: cpu, disk, network (default: all three)"},
+                "start": {"type": "string", "description": "Start timestamp in ISO 8601 (e.g. 2025-01-01T00:00:00Z)"},
+                "end": {"type": "string", "description": "End timestamp in ISO 8601"},
+                "step": {"type": "number", "description": "Resolution step in seconds (optional)"},
+            },
+            "required": ["server_id", "start", "end"],
+        },
+        execute=_hetzner_get_server_metrics,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_list_load_balancers",
+        description="List all Hetzner load balancers with targets, services, health checks, and algorithm.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "per_page": {"type": "number", "description": "Results per page (default 50)"},
+                "name": {"type": "string", "description": "Filter by name"},
+            },
+        },
+        execute=_hetzner_list_load_balancers,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_get_load_balancer",
+        description="Get details of a specific Hetzner load balancer by ID.",
+        parameters={
+            "type": "object",
+            "properties": {"load_balancer_id": {"type": "string", "description": "Load Balancer ID"}},
+            "required": ["load_balancer_id"],
+        },
+        execute=_hetzner_get_load_balancer,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_get_load_balancer_metrics",
+        description="Get metrics for a Hetzner load balancer (requests/sec, bandwidth, connections/sec). Requires ISO 8601 start/end timestamps.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "load_balancer_id": {"type": "string", "description": "Load Balancer ID"},
+                "type": {"type": "string", "description": "Comma-separated: requests_per_second, bandwidth.in, bandwidth.out, connections_per_second"},
+                "start": {"type": "string", "description": "Start timestamp in ISO 8601"},
+                "end": {"type": "string", "description": "End timestamp in ISO 8601"},
+                "step": {"type": "number", "description": "Resolution step in seconds (optional)"},
+            },
+            "required": ["load_balancer_id", "start", "end"],
+        },
+        execute=_hetzner_get_load_balancer_metrics,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_list_firewalls",
+        description="List all Hetzner firewalls with their rules and applied resources.",
+        parameters={"type": "object", "properties": {}},
+        execute=_hetzner_list_firewalls,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_list_networks",
+        description="List all Hetzner private networks with subnets, routes, and attached servers.",
+        parameters={"type": "object", "properties": {}},
+        execute=_hetzner_list_networks,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_get_network",
+        description="Get details of a specific Hetzner network by ID.",
+        parameters={
+            "type": "object",
+            "properties": {"network_id": {"type": "string", "description": "Network ID"}},
+            "required": ["network_id"],
+        },
+        execute=_hetzner_get_network,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_list_volumes",
+        description="List all Hetzner volumes with size, status, and attached server.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "description": "Filter by status: creating, available"},
+            },
+        },
+        execute=_hetzner_list_volumes,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_list_floating_ips",
+        description="List all Hetzner floating IPs with assignment status and location.",
+        parameters={"type": "object", "properties": {}},
+        execute=_hetzner_list_floating_ips,
+        category="hetzner",
+    ),
+    ToolDefinition(
+        name="hetzner_list_ssh_keys",
+        description="List all SSH keys in the Hetzner project.",
+        parameters={"type": "object", "properties": {}},
+        execute=_hetzner_list_ssh_keys,
+        category="hetzner",
+    ),
+]
+
+HETZNER_TOOL_NAMES = [t.name for t in HETZNER_TOOLS]
+
+
+def register_hetzner_tools() -> None:
+    for tool in HETZNER_TOOLS:
+        tool_registry.define(tool)

--- a/agent_service/agent/orchestrator.py
+++ b/agent_service/agent/orchestrator.py
@@ -18,6 +18,7 @@ from .integrations.tool_registry import tool_registry
 from .integrations.aws import register_aws_tools
 from .integrations.newrelic import register_newrelic_tools
 from .integrations.pagerduty import register_pagerduty_tools
+from .integrations.hetzner import register_hetzner_tools
 from .name_matcher import normalize_name
 from .prompts import SYSTEM, EVALUATION_SYSTEM, CORRELATION_ANALYSIS
 from .sub_agents import (
@@ -45,6 +46,7 @@ INTEGRATION_TO_AGENT: dict[str, SubAgentType] = {
     "sentry": "error_monitoring",
     "aws": "infrastructure",
     "pagerduty": "alerting",
+    "hetzner": "infrastructure",
 }
 
 AGENT_CLASSES: dict[SubAgentType, type[BaseSubAgent]] = {
@@ -76,6 +78,7 @@ async def orchestrate(request: AgentRunRequest) -> AsyncGenerator[str, None]:
     register_aws_tools(resource_maps=request.resource_maps)
     register_newrelic_tools()
     register_pagerduty_tools()
+    register_hetzner_tools()
 
     # Initialize MCP
     mcp = MCPClientManager(request.settings)
@@ -1513,6 +1516,8 @@ def _get_enabled_integrations(settings: dict[str, Any]) -> list[str]:
         enabled.append("github")
     if _has_any_instance(settings, "pagerduty", "api_key"):
         enabled.append("pagerduty")
+    if _has_any_instance(settings, "hetzner", "api_token"):
+        enabled.append("hetzner")
     return enabled
 
 

--- a/agent_service/agent/sub_agents/infrastructure.py
+++ b/agent_service/agent/sub_agents/infrastructure.py
@@ -65,8 +65,10 @@ class InfrastructureAgent(BaseSubAgent):
         # plus custom boto3 tools from the registry
         mcp_tools = self.get_mcp_tools("aws")
         registry_tools = self.get_registry_tools_by_category("aws")
-        hetzner_tools = self.get_registry_tools_by_category("hetzner")
-        return [*mcp_tools, *registry_tools, *hetzner_tools]
+        tools = [*mcp_tools, *registry_tools]
+        if "hetzner" in self.config.enabled_integrations:
+            tools.extend(self.get_registry_tools_by_category("hetzner"))
+        return tools
 
     def get_system_prompt(self) -> str:
         # Check if any discovered RDS resources have Performance Insights enabled

--- a/agent_service/agent/sub_agents/infrastructure.py
+++ b/agent_service/agent/sub_agents/infrastructure.py
@@ -65,7 +65,8 @@ class InfrastructureAgent(BaseSubAgent):
         # plus custom boto3 tools from the registry
         mcp_tools = self.get_mcp_tools("aws")
         registry_tools = self.get_registry_tools_by_category("aws")
-        return [*mcp_tools, *registry_tools]
+        hetzner_tools = self.get_registry_tools_by_category("hetzner")
+        return [*mcp_tools, *registry_tools, *hetzner_tools]
 
     def get_system_prompt(self) -> str:
         # Check if any discovered RDS resources have Performance Insights enabled

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -31,7 +31,7 @@ module API
 
     def test_connection
       integration = params.require(:integration)
-      valid = %w[openai newrelic sentry aws github pagerduty]
+      valid = %w[openai newrelic sentry aws github pagerduty hetzner]
       return render_error('Invalid integration name') unless valid.include?(integration)
 
       @result = if integration_status[integration.to_sym]
@@ -44,7 +44,7 @@ module API
     def destroy_integration
       integration = params[:integration]
       index = params[:index].to_i
-      valid = %w[newrelic sentry aws github pagerduty]
+      valid = %w[newrelic sentry aws github pagerduty hetzner]
       return render_error('Invalid integration name') unless valid.include?(integration)
 
       prefix = "#{integration}.#{index}."
@@ -114,7 +114,8 @@ module API
         sentry: keys.any? { |k| k.match?(/\Asentry\.\d+\.auth_token\z/) },
         aws: keys.any? { |k| k.match?(/\Aaws\.\d+\.access_key_id\z/) },
         github: keys.any? { |k| k.match?(/\Agithub\.\d+\.token\z/) },
-        pagerduty: keys.any? { |k| k.match?(/\Apagerduty\.\d+\.api_key\z/) }
+        pagerduty: keys.any? { |k| k.match?(/\Apagerduty\.\d+\.api_key\z/) },
+        hetzner: keys.any? { |k| k.match?(/\Ahetzner\.\d+\.api_token\z/) }
       }
     end
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -7,7 +7,7 @@ class Setting < ApplicationRecord
   validates :value, presence: true
   validate :openai_key_format, if: -> { key == 'openai.api_key' }
 
-  SENSITIVE_SUFFIXES = %w[api_key secret_access_key auth_token token].freeze
+  SENSITIVE_SUFFIXES = %w[api_key secret_access_key auth_token token api_token].freeze
 
   scope :visible, -> { where.not('key LIKE ?', '_internal.%') }
 

--- a/frontend/components/SettingsPanel.vue
+++ b/frontend/components/SettingsPanel.vue
@@ -278,6 +278,17 @@ const INTEGRATIONS: IntegrationDef[] = [
       { key: 'repo', label: 'Repository Name', type: 'text', placeholder: 'myapp' },
     ],
   },
+  {
+    id: 'hetzner',
+    title: 'Hetzner Cloud',
+    description: 'Cloud infrastructure — servers, load balancers, networks, firewalls, and metrics',
+    icon: 'simple-icons:hetzner',
+    multiple: true,
+    fields: [
+      { key: 'api_token', label: 'API Token', type: 'password', placeholder: 'YOUR_TOKEN_HERE' },
+    ],
+    hint: 'Generate at Hetzner Cloud Console \u2192 Security \u2192 API Tokens. Read-only permission is sufficient.',
+  },
 ];
 
 // ── Component state ──


### PR DESCRIPTION
## Summary
- Add native Hetzner Cloud API integration with 12 tools: servers (list/get/metrics), load balancers (list/get/metrics), firewalls, networks, volumes, floating IPs, and SSH keys
- Resource discovery for Hetzner servers populates resource maps automatically
- Routes through the existing infrastructure sub-agent
- Settings UI with API token configuration (supports multiple accounts)

## Test plan
- [x] Verified API token saves and encrypts correctly
- [x] Verified integration status endpoint detects Hetzner config
- [x] Verified Python agent imports and tool registration
- [x] Test agent queries against a live Hetzner account

🤖 Generated with [Claude Code](https://claude.com/claude-code)