### PR TITLE
feat: Add DigitalOcean integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ All integrations are configured in **Settings** from the UI. Credentials are enc
 | **AWS** | Native (boto3) | CloudWatch, EC2, Lambda, RDS, ECS |
 | **GitHub** | MCP — `@modelcontextprotocol/server-github` (stdio) | Code search, file content, commits, blame |
 | **PagerDuty** | Native + MCP — `mcp.pagerduty.com` (streamable-http) | Incidents, services, escalation policies, on-call schedules |
+| **DigitalOcean** | Native (REST API v2) | Droplets, databases, load balancers, Kubernetes, firewalls, metrics |
 
 All integrations except OpenAI support multiple instances (e.g. multiple AWS accounts).
 

--- a/agent_service/agent/discovery.py
+++ b/agent_service/agent/discovery.py
@@ -392,6 +392,69 @@ async def _discover_sentry(settings: dict[str, Any]) -> list[dict[str, Any]]:
     return nodes
 
 
+# ── DigitalOcean ─────────────────────────────────────────────────
+
+
+async def _discover_digitalocean_instance(instance: dict[str, str]) -> list[dict[str, Any]]:
+    api_token = instance.get("api_token")
+    if not api_token:
+        return []
+
+    headers = {"Authorization": f"Bearer {api_token}"}
+    nodes: list[dict[str, Any]] = []
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.digitalocean.com/v2/droplets?per_page=200",
+                headers=headers,
+                timeout=30,
+            )
+            resp.raise_for_status()
+
+        droplets = resp.json().get("droplets", [])
+        for d in droplets:
+            networks = d.get("networks", {})
+            ipv4_list = networks.get("v4", [])
+            public_ip = next((n["ip_address"] for n in ipv4_list if n.get("type") == "public"), "")
+
+            nodes.append(_node(
+                name=d["name"],
+                type="droplet",
+                source="digitalocean",
+                external_id=str(d.get("id", "")),
+                attrs={
+                    "status": d.get("status", ""),
+                    "size": d.get("size_slug", ""),
+                    "public_ip": public_ip,
+                    "region": d.get("region", {}).get("slug", ""),
+                },
+            ))
+
+        logger.info("DigitalOcean discovery: %d droplets", len(nodes))
+    except Exception as exc:
+        logger.warning("DigitalOcean discovery failed: %s", exc)
+
+    return nodes
+
+
+async def _discover_digitalocean(settings: dict[str, Any]) -> list[dict[str, Any]]:
+    instances = _get_instances(settings, "digitalocean")
+    if not instances:
+        return []
+    results = await asyncio.gather(
+        *[_discover_digitalocean_instance(inst) for inst in instances],
+        return_exceptions=True,
+    )
+    nodes: list[dict[str, Any]] = []
+    for result in results:
+        if isinstance(result, Exception):
+            logger.warning("DigitalOcean instance discovery failed: %s", result)
+        else:
+            nodes.extend(result)
+    return nodes
+
+
 # ── Edge inference ───────────────────────────────────────────────
 
 
@@ -526,6 +589,7 @@ async def discover_resources(
         _discover_aws(settings),
         _discover_pagerduty(settings),
         _discover_sentry(settings),
+        _discover_digitalocean(settings),
     ]
 
     results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/agent_service/agent/integrations/digitalocean/__init__.py
+++ b/agent_service/agent/integrations/digitalocean/__init__.py
@@ -1,0 +1,362 @@
+"""DigitalOcean custom tools — REST API v2 integration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from ..tool_registry import ToolDefinition, tool_registry
+
+DO_BASE = "https://api.digitalocean.com/v2"
+
+
+def get_digitalocean_credentials(settings: dict[str, Any], instance: int = 0) -> dict[str, str]:
+    api_token = settings.get(f"digitalocean.{instance}.api_token")
+    if not api_token:
+        raise ValueError("DigitalOcean API token not configured.")
+    return {"api_token": api_token}
+
+
+def _do_headers(settings: dict[str, Any]) -> dict[str, str]:
+    creds = get_digitalocean_credentials(settings)
+    return {
+        "Authorization": f"Bearer {creds['api_token']}",
+        "Content-Type": "application/json",
+    }
+
+
+# ── Droplets ─────────────────────────────────────────────────────
+
+
+async def _do_list_droplets(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    params: dict[str, Any] = {"per_page": args.get("per_page", 50)}
+    if args.get("page"):
+        params["page"] = args["page"]
+    if args.get("tag_name"):
+        params["tag_name"] = args["tag_name"]
+    if args.get("name"):
+        params["name"] = args["name"]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/droplets", headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+
+    droplets = resp.json().get("droplets", [])
+    return {"title": f"Droplets ({len(droplets)})", "output": json.dumps({"droplets": droplets}, indent=2)}
+
+
+async def _do_get_droplet(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/droplets/{args['droplet_id']}", headers=headers, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Droplet: {args['droplet_id']}", "output": json.dumps(resp.json().get("droplet", {}), indent=2)}
+
+
+# ── Droplet Metrics ──────────────────────────────────────────────
+
+
+async def _do_get_droplet_cpu(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    params = {"host_id": args["host_id"], "start": args["start"], "end": args["end"]}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/monitoring/metrics/droplet/cpu", headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"CPU Metrics: {args['host_id']}", "output": json.dumps(resp.json().get("data", {}), indent=2)}
+
+
+async def _do_get_droplet_memory_free(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    params = {"host_id": args["host_id"], "start": args["start"], "end": args["end"]}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/monitoring/metrics/droplet/memory_free", headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Memory Free: {args['host_id']}", "output": json.dumps(resp.json().get("data", {}), indent=2)}
+
+
+async def _do_get_droplet_bandwidth(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    params = {
+        "host_id": args["host_id"],
+        "start": args["start"],
+        "end": args["end"],
+        "interface": args.get("interface", "public"),
+        "direction": args.get("direction", "inbound"),
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/monitoring/metrics/droplet/bandwidth", headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Bandwidth: {args['host_id']}", "output": json.dumps(resp.json().get("data", {}), indent=2)}
+
+
+# ── Databases ────────────────────────────────────────────────────
+
+
+async def _do_list_databases(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/databases", headers=headers, timeout=30)
+        resp.raise_for_status()
+    databases = resp.json().get("databases", [])
+    return {"title": f"Databases ({len(databases)})", "output": json.dumps({"databases": databases}, indent=2)}
+
+
+async def _do_get_database(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/databases/{args['database_id']}", headers=headers, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Database: {args['database_id']}", "output": json.dumps(resp.json().get("database", {}), indent=2)}
+
+
+# ── Load Balancers ───────────────────────────────────────────────
+
+
+async def _do_list_load_balancers(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/load_balancers", headers=headers, timeout=30)
+        resp.raise_for_status()
+    lbs = resp.json().get("load_balancers", [])
+    return {"title": f"Load Balancers ({len(lbs)})", "output": json.dumps({"load_balancers": lbs}, indent=2)}
+
+
+async def _do_get_load_balancer(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/load_balancers/{args['load_balancer_id']}", headers=headers, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Load Balancer: {args['load_balancer_id']}", "output": json.dumps(resp.json().get("load_balancer", {}), indent=2)}
+
+
+# ── Firewalls ────────────────────────────────────────────────────
+
+
+async def _do_list_firewalls(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/firewalls", headers=headers, timeout=30)
+        resp.raise_for_status()
+    firewalls = resp.json().get("firewalls", [])
+    return {"title": f"Firewalls ({len(firewalls)})", "output": json.dumps({"firewalls": firewalls}, indent=2)}
+
+
+# ── Kubernetes ───────────────────────────────────────────────────
+
+
+async def _do_list_kubernetes_clusters(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/kubernetes/clusters", headers=headers, timeout=30)
+        resp.raise_for_status()
+    clusters = resp.json().get("kubernetes_clusters", [])
+    return {"title": f"Kubernetes Clusters ({len(clusters)})", "output": json.dumps({"kubernetes_clusters": clusters}, indent=2)}
+
+
+async def _do_get_kubernetes_cluster(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/kubernetes/clusters/{args['cluster_id']}", headers=headers, timeout=30)
+        resp.raise_for_status()
+    return {"title": f"Kubernetes Cluster: {args['cluster_id']}", "output": json.dumps(resp.json().get("kubernetes_cluster", {}), indent=2)}
+
+
+# ── Monitoring Alerts ────────────────────────────────────────────
+
+
+async def _do_list_alert_policies(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/monitoring/alerts", headers=headers, timeout=30)
+        resp.raise_for_status()
+    policies = resp.json().get("policies", [])
+    return {"title": f"Alert Policies ({len(policies)})", "output": json.dumps({"policies": policies}, indent=2)}
+
+
+# ── Domains ──────────────────────────────────────────────────────
+
+
+async def _do_list_domains(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/domains", headers=headers, timeout=30)
+        resp.raise_for_status()
+    domains = resp.json().get("domains", [])
+    return {"title": f"Domains ({len(domains)})", "output": json.dumps({"domains": domains}, indent=2)}
+
+
+# ── Volumes ──────────────────────────────────────────────────────
+
+
+async def _do_list_volumes(args: dict, ctx: Any) -> dict:
+    headers = _do_headers(ctx.settings)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{DO_BASE}/volumes", headers=headers, timeout=30)
+        resp.raise_for_status()
+    volumes = resp.json().get("volumes", [])
+    return {"title": f"Volumes ({len(volumes)})", "output": json.dumps({"volumes": volumes}, indent=2)}
+
+
+# ── Tool Definitions ─────────────────────────────────────────────
+
+_METRICS_PARAMS = {
+    "type": "object",
+    "properties": {
+        "host_id": {"type": "string", "description": "Droplet ID"},
+        "start": {"type": "string", "description": "Start timestamp (Unix epoch seconds)"},
+        "end": {"type": "string", "description": "End timestamp (Unix epoch seconds)"},
+    },
+    "required": ["host_id", "start", "end"],
+}
+
+DIGITALOCEAN_TOOLS = [
+    ToolDefinition(
+        name="do_list_droplets",
+        description="List all DigitalOcean Droplets with status, IPs, region, size, tags, and VPC info.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "per_page": {"type": "number", "description": "Results per page (default 50)"},
+                "page": {"type": "number", "description": "Page number"},
+                "tag_name": {"type": "string", "description": "Filter by tag"},
+                "name": {"type": "string", "description": "Filter by name"},
+            },
+        },
+        execute=_do_list_droplets,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_get_droplet",
+        description="Get details of a specific Droplet by ID, including status, IPs, region, size, volumes, and tags.",
+        parameters={
+            "type": "object",
+            "properties": {"droplet_id": {"type": "string", "description": "Droplet ID"}},
+            "required": ["droplet_id"],
+        },
+        execute=_do_get_droplet,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_get_droplet_cpu",
+        description="Get CPU utilization metrics for a Droplet. Requires host_id (Droplet ID) and Unix epoch start/end timestamps.",
+        parameters=_METRICS_PARAMS,
+        execute=_do_get_droplet_cpu,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_get_droplet_memory_free",
+        description="Get free memory metrics for a Droplet. Requires host_id (Droplet ID) and Unix epoch start/end timestamps.",
+        parameters=_METRICS_PARAMS,
+        execute=_do_get_droplet_memory_free,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_get_droplet_bandwidth",
+        description="Get bandwidth metrics for a Droplet (public/private, inbound/outbound). Requires host_id and Unix epoch timestamps.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "host_id": {"type": "string", "description": "Droplet ID"},
+                "start": {"type": "string", "description": "Start timestamp (Unix epoch seconds)"},
+                "end": {"type": "string", "description": "End timestamp (Unix epoch seconds)"},
+                "interface": {"type": "string", "description": "Network interface: public or private (default: public)"},
+                "direction": {"type": "string", "description": "Traffic direction: inbound or outbound (default: inbound)"},
+            },
+            "required": ["host_id", "start", "end"],
+        },
+        execute=_do_get_droplet_bandwidth,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_list_databases",
+        description="List all DigitalOcean managed databases with engine, status, region, and connection details.",
+        parameters={"type": "object", "properties": {}},
+        execute=_do_list_databases,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_get_database",
+        description="Get details of a specific managed database by ID.",
+        parameters={
+            "type": "object",
+            "properties": {"database_id": {"type": "string", "description": "Database cluster ID"}},
+            "required": ["database_id"],
+        },
+        execute=_do_get_database,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_list_load_balancers",
+        description="List all DigitalOcean load balancers with health checks, forwarding rules, and Droplet pools.",
+        parameters={"type": "object", "properties": {}},
+        execute=_do_list_load_balancers,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_get_load_balancer",
+        description="Get details of a specific load balancer by ID.",
+        parameters={
+            "type": "object",
+            "properties": {"load_balancer_id": {"type": "string", "description": "Load Balancer ID"}},
+            "required": ["load_balancer_id"],
+        },
+        execute=_do_get_load_balancer,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_list_firewalls",
+        description="List all DigitalOcean firewalls with rules and associated Droplets.",
+        parameters={"type": "object", "properties": {}},
+        execute=_do_list_firewalls,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_list_kubernetes_clusters",
+        description="List all DigitalOcean Kubernetes (DOKS) clusters with node pools, version, and status.",
+        parameters={"type": "object", "properties": {}},
+        execute=_do_list_kubernetes_clusters,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_get_kubernetes_cluster",
+        description="Get details of a specific Kubernetes cluster by ID.",
+        parameters={
+            "type": "object",
+            "properties": {"cluster_id": {"type": "string", "description": "Kubernetes cluster ID"}},
+            "required": ["cluster_id"],
+        },
+        execute=_do_get_kubernetes_cluster,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_list_alert_policies",
+        description="List all DigitalOcean monitoring alert policies with thresholds and targets.",
+        parameters={"type": "object", "properties": {}},
+        execute=_do_list_alert_policies,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_list_domains",
+        description="List all DigitalOcean domains.",
+        parameters={"type": "object", "properties": {}},
+        execute=_do_list_domains,
+        category="digitalocean",
+    ),
+    ToolDefinition(
+        name="do_list_volumes",
+        description="List all DigitalOcean block storage volumes with size, status, and attached Droplets.",
+        parameters={"type": "object", "properties": {}},
+        execute=_do_list_volumes,
+        category="digitalocean",
+    ),
+]
+
+DIGITALOCEAN_TOOL_NAMES = [t.name for t in DIGITALOCEAN_TOOLS]
+
+
+def register_digitalocean_tools() -> None:
+    for tool in DIGITALOCEAN_TOOLS:
+        tool_registry.define(tool)

--- a/agent_service/agent/orchestrator.py
+++ b/agent_service/agent/orchestrator.py
@@ -18,6 +18,7 @@ from .integrations.tool_registry import tool_registry
 from .integrations.aws import register_aws_tools
 from .integrations.newrelic import register_newrelic_tools
 from .integrations.pagerduty import register_pagerduty_tools
+from .integrations.digitalocean import register_digitalocean_tools
 from .name_matcher import normalize_name
 from .prompts import SYSTEM, EVALUATION_SYSTEM, CORRELATION_ANALYSIS
 from .sub_agents import (
@@ -45,6 +46,7 @@ INTEGRATION_TO_AGENT: dict[str, SubAgentType] = {
     "sentry": "error_monitoring",
     "aws": "infrastructure",
     "pagerduty": "alerting",
+    "digitalocean": "infrastructure",
 }
 
 AGENT_CLASSES: dict[SubAgentType, type[BaseSubAgent]] = {
@@ -76,6 +78,7 @@ async def orchestrate(request: AgentRunRequest) -> AsyncGenerator[str, None]:
     register_aws_tools(resource_maps=request.resource_maps)
     register_newrelic_tools()
     register_pagerduty_tools()
+    register_digitalocean_tools()
 
     # Initialize MCP
     mcp = MCPClientManager(request.settings)
@@ -1513,6 +1516,8 @@ def _get_enabled_integrations(settings: dict[str, Any]) -> list[str]:
         enabled.append("github")
     if _has_any_instance(settings, "pagerduty", "api_key"):
         enabled.append("pagerduty")
+    if _has_any_instance(settings, "digitalocean", "api_token"):
+        enabled.append("digitalocean")
     return enabled
 
 

--- a/agent_service/agent/sub_agents/infrastructure.py
+++ b/agent_service/agent/sub_agents/infrastructure.py
@@ -65,7 +65,10 @@ class InfrastructureAgent(BaseSubAgent):
         # plus custom boto3 tools from the registry
         mcp_tools = self.get_mcp_tools("aws")
         registry_tools = self.get_registry_tools_by_category("aws")
-        return [*mcp_tools, *registry_tools]
+        tools = [*mcp_tools, *registry_tools]
+        if "digitalocean" in self.config.enabled_integrations:
+            tools.extend(self.get_registry_tools_by_category("digitalocean"))
+        return tools
 
     def get_system_prompt(self) -> str:
         # Check if any discovered RDS resources have Performance Insights enabled

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -31,7 +31,7 @@ module API
 
     def test_connection
       integration = params.require(:integration)
-      valid = %w[openai newrelic sentry aws github pagerduty]
+      valid = %w[openai newrelic sentry aws github pagerduty digitalocean]
       return render_error('Invalid integration name') unless valid.include?(integration)
 
       @result = if integration_status[integration.to_sym]
@@ -44,7 +44,7 @@ module API
     def destroy_integration
       integration = params[:integration]
       index = params[:index].to_i
-      valid = %w[newrelic sentry aws github pagerduty]
+      valid = %w[newrelic sentry aws github pagerduty digitalocean]
       return render_error('Invalid integration name') unless valid.include?(integration)
 
       prefix = "#{integration}.#{index}."
@@ -114,7 +114,8 @@ module API
         sentry: keys.any? { |k| k.match?(/\Asentry\.\d+\.auth_token\z/) },
         aws: keys.any? { |k| k.match?(/\Aaws\.\d+\.access_key_id\z/) },
         github: keys.any? { |k| k.match?(/\Agithub\.\d+\.token\z/) },
-        pagerduty: keys.any? { |k| k.match?(/\Apagerduty\.\d+\.api_key\z/) }
+        pagerduty: keys.any? { |k| k.match?(/\Apagerduty\.\d+\.api_key\z/) },
+        digitalocean: keys.any? { |k| k.match?(/\Adigitalocean\.\d+\.api_token\z/) }
       }
     end
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -7,7 +7,7 @@ class Setting < ApplicationRecord
   validates :value, presence: true
   validate :openai_key_format, if: -> { key == 'openai.api_key' }
 
-  SENSITIVE_SUFFIXES = %w[api_key secret_access_key auth_token token].freeze
+  SENSITIVE_SUFFIXES = %w[api_key secret_access_key auth_token token api_token].freeze
 
   scope :visible, -> { where.not('key LIKE ?', '_internal.%') }
 

--- a/frontend/components/SettingsPanel.vue
+++ b/frontend/components/SettingsPanel.vue
@@ -278,6 +278,17 @@ const INTEGRATIONS: IntegrationDef[] = [
       { key: 'repo', label: 'Repository Name', type: 'text', placeholder: 'myapp' },
     ],
   },
+  {
+    id: 'digitalocean',
+    title: 'DigitalOcean',
+    description: 'Cloud infrastructure — Droplets, managed databases, load balancers, Kubernetes, and metrics',
+    icon: 'simple-icons:digitalocean',
+    multiple: true,
+    fields: [
+      { key: 'api_token', label: 'API Token', type: 'password', placeholder: 'dop_v1_...' },
+    ],
+    hint: 'Generate at DigitalOcean \u2192 API \u2192 Tokens. Read-only scope is sufficient.',
+  },
 ];
 
 // ── Component state ──


### PR DESCRIPTION
Add native DigitalOcean API v2 integration with 15 tools: Droplets (list/get/CPU/memory/bandwidth metrics), managed databases (list/get), load balancers (list/get), firewalls, Kubernetes clusters (list/get), alert policies, domains, and volumes.

Includes resource discovery for Droplets in resource maps, gated tool exposure in the infrastructure sub-agent, api_token marked as sensitive, and Settings UI with API token configuration.